### PR TITLE
fix: fix IDL user account data of create instruction

### DIFF
--- a/crates/pumpfun-cpi/idl.classic.json
+++ b/crates/pumpfun-cpi/idl.classic.json
@@ -140,8 +140,8 @@
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": false
+          "isMut": true,
+          "isSigner": true
         },
         {
           "name": "systemProgram",


### PR DESCRIPTION
## Issue:
The program was failing to call the create instruction via CPI due to incorrect account configuration.

## Fix:
Updated the user account configuration in the create instruction within the Solana Anchor IDL. The user account was initially set with "isMut": false and "isSigner": false, which caused the CPI call to fail. The updated configuration sets "isMut": true and "isSigner": true, enabling the program to successfully perform the CPI call.

## Testing:
Verified that the CPI call to the create instruction now succeeds with the updated account configuration.