### PR TITLE
✨ feat: update SDK to support new creator fee protocol

### DIFF
--- a/src/accounts/bonding_curve.rs
+++ b/src/accounts/bonding_curve.rs
@@ -26,301 +26,308 @@
 //! - `get_buy_out_price`: Calculates the price to buy out all remaining tokens
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use solana_sdk::pubkey::Pubkey;
 
 /// Represents a bonding curve for token pricing and liquidity management
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct BondingCurveAccount {
-    /// Unique identifier for the bonding curve
-    pub discriminator: u64,
-    /// Virtual token reserves used for price calculations
-    pub virtual_token_reserves: u64,
-    /// Virtual SOL reserves used for price calculations
-    pub virtual_sol_reserves: u64,
-    /// Actual token reserves available for trading
-    pub real_token_reserves: u64,
-    /// Actual SOL reserves available for trading
-    pub real_sol_reserves: u64,
-    /// Total supply of tokens
-    pub token_total_supply: u64,
-    /// Whether the bonding curve is complete/finalized
-    pub complete: bool,
+   /// Unique identifier for the bonding curve
+   pub discriminator: u64,
+   /// Virtual token reserves used for price calculations
+   pub virtual_token_reserves: u64,
+   /// Virtual SOL reserves used for price calculations
+   pub virtual_sol_reserves: u64,
+   /// Actual token reserves available for trading
+   pub real_token_reserves: u64,
+   /// Actual SOL reserves available for trading
+   pub real_sol_reserves: u64,
+   /// Total supply of tokens
+   pub token_total_supply: u64,
+   /// Whether the bonding curve is complete/finalized
+   pub complete: bool,
+   /// Token creator's address
+   pub creator: Pubkey,
 }
 
 impl BondingCurveAccount {
-    /// Creates a new bonding curve instance
-    ///
-    /// # Arguments
-    /// * `discriminator` - Unique identifier for the curve
-    /// * `virtual_token_reserves` - Virtual token reserves for price calculations
-    /// * `virtual_sol_reserves` - Virtual SOL reserves for price calculations
-    /// * `real_token_reserves` - Actual token reserves available
-    /// * `real_sol_reserves` - Actual SOL reserves available
-    /// * `token_total_supply` - Total supply of tokens
-    /// * `complete` - Whether the curve is complete
-    pub fn new(
-        discriminator: u64,
-        virtual_token_reserves: u64,
-        virtual_sol_reserves: u64,
-        real_token_reserves: u64,
-        real_sol_reserves: u64,
-        token_total_supply: u64,
-        complete: bool,
-    ) -> Self {
-        Self {
-            discriminator,
-            virtual_token_reserves,
-            virtual_sol_reserves,
-            real_token_reserves,
-            real_sol_reserves,
-            token_total_supply,
-            complete,
-        }
-    }
+   /// Creates a new bonding curve instance
+   ///
+   /// # Arguments
+   /// * `discriminator` - Unique identifier for the curve
+   /// * `virtual_token_reserves` - Virtual token reserves for price calculations
+   /// * `virtual_sol_reserves` - Virtual SOL reserves for price calculations
+   /// * `real_token_reserves` - Actual token reserves available
+   /// * `real_sol_reserves` - Actual SOL reserves available
+   /// * `token_total_supply` - Total supply of tokens
+   /// * `complete` - Whether the curve is complete
+   pub fn new(
+      discriminator: u64,
+      virtual_token_reserves: u64,
+      virtual_sol_reserves: u64,
+      real_token_reserves: u64,
+      real_sol_reserves: u64,
+      token_total_supply: u64,
+      complete: bool,
+      creator: Pubkey,
+   ) -> Self {
+      Self {
+         discriminator,
+         virtual_token_reserves,
+         virtual_sol_reserves,
+         real_token_reserves,
+         real_sol_reserves,
+         token_total_supply,
+         complete,
+         creator,
+      }
+   }
 
-    /// Calculates the amount of tokens received for a given SOL amount
-    ///
-    /// # Arguments
-    /// * `amount` - Amount of SOL to spend
-    ///
-    /// # Returns
-    /// * `Ok(u64)` - Amount of tokens that would be received
-    /// * `Err(&str)` - Error message if curve is complete
-    pub fn get_buy_price(&self, amount: u64) -> Result<u64, &'static str> {
-        if self.complete {
-            return Err("Curve is complete");
-        }
+   /// Calculates the amount of tokens received for a given SOL amount
+   ///
+   /// # Arguments
+   /// * `amount` - Amount of SOL to spend
+   ///
+   /// # Returns
+   /// * `Ok(u64)` - Amount of tokens that would be received
+   /// * `Err(&str)` - Error message if curve is complete
+   pub fn get_buy_price(&self, amount: u64) -> Result<u64, &'static str> {
+      if self.complete {
+         return Err("Curve is complete");
+      }
 
-        if amount == 0 {
-            return Ok(0);
-        }
+      if amount == 0 {
+         return Ok(0);
+      }
 
-        // Calculate the product of virtual reserves using u128 to avoid overflow
-        let n: u128 = (self.virtual_sol_reserves as u128) * (self.virtual_token_reserves as u128);
+      // Calculate the product of virtual reserves using u128 to avoid overflow
+      let n: u128 = (self.virtual_sol_reserves as u128) * (self.virtual_token_reserves as u128);
 
-        // Calculate the new virtual sol reserves after the purchase
-        let i: u128 = (self.virtual_sol_reserves as u128) + (amount as u128);
+      // Calculate the new virtual sol reserves after the purchase
+      let i: u128 = (self.virtual_sol_reserves as u128) + (amount as u128);
 
-        // Calculate the new virtual token reserves after the purchase
-        let r: u128 = n / i + 1;
+      // Calculate the new virtual token reserves after the purchase
+      let r: u128 = n / i + 1;
 
-        // Calculate the amount of tokens to be purchased
-        let s: u128 = (self.virtual_token_reserves as u128) - r;
+      // Calculate the amount of tokens to be purchased
+      let s: u128 = (self.virtual_token_reserves as u128) - r;
 
-        // Convert back to u64 and return the minimum of calculated tokens and real reserves
-        let s_u64 = s as u64;
-        Ok(if s_u64 < self.real_token_reserves {
-            s_u64
-        } else {
-            self.real_token_reserves
-        })
-    }
+      // Convert back to u64 and return the minimum of calculated tokens and real reserves
+      let s_u64 = s as u64;
+      Ok(if s_u64 < self.real_token_reserves {
+         s_u64
+      } else {
+         self.real_token_reserves
+      })
+   }
 
-    /// Calculates the amount of SOL received for selling tokens
-    ///
-    /// # Arguments
-    /// * `amount` - Amount of tokens to sell
-    /// * `fee_basis_points` - Fee in basis points (1/100th of a percent)
-    ///
-    /// # Returns
-    /// * `Ok(u64)` - Amount of SOL that would be received after fees
-    /// * `Err(&str)` - Error message if curve is complete
-    pub fn get_sell_price(&self, amount: u64, fee_basis_points: u64) -> Result<u64, &'static str> {
-        if self.complete {
-            return Err("Curve is complete");
-        }
+   /// Calculates the amount of SOL received for selling tokens
+   ///
+   /// # Arguments
+   /// * `amount` - Amount of tokens to sell
+   /// * `fee_basis_points` - Fee in basis points (1/100th of a percent)
+   ///
+   /// # Returns
+   /// * `Ok(u64)` - Amount of SOL that would be received after fees
+   /// * `Err(&str)` - Error message if curve is complete
+   pub fn get_sell_price(&self, amount: u64, fee_basis_points: u64) -> Result<u64, &'static str> {
+      if self.complete {
+         return Err("Curve is complete");
+      }
 
-        if amount == 0 {
-            return Ok(0);
-        }
+      if amount == 0 {
+         return Ok(0);
+      }
 
-        // Calculate the proportional amount of virtual sol reserves to be received using u128
-        let n: u128 = ((amount as u128) * (self.virtual_sol_reserves as u128))
-            / ((self.virtual_token_reserves as u128) + (amount as u128));
+      // Calculate the proportional amount of virtual sol reserves to be received using u128
+      let n: u128 = ((amount as u128) * (self.virtual_sol_reserves as u128))
+         / ((self.virtual_token_reserves as u128) + (amount as u128));
 
-        // Calculate the fee amount in the same units
-        let a: u128 = (n * (fee_basis_points as u128)) / 10000;
+      // Calculate the fee amount in the same units
+      let a: u128 = (n * (fee_basis_points as u128)) / 10000;
 
-        // Return the net amount after deducting the fee, converting back to u64
-        Ok((n - a) as u64)
-    }
+      // Return the net amount after deducting the fee, converting back to u64
+      Ok((n - a) as u64)
+   }
 
-    /// Calculates the current market cap in SOL
-    pub fn get_market_cap_sol(&self) -> u64 {
-        if self.virtual_token_reserves == 0 {
-            return 0;
-        }
+   /// Calculates the current market cap in SOL
+   pub fn get_market_cap_sol(&self) -> u64 {
+      if self.virtual_token_reserves == 0 {
+         return 0;
+      }
 
-        ((self.token_total_supply as u128) * (self.virtual_sol_reserves as u128)
-            / (self.virtual_token_reserves as u128)) as u64
-    }
+      ((self.token_total_supply as u128) * (self.virtual_sol_reserves as u128)
+         / (self.virtual_token_reserves as u128)) as u64
+   }
 
-    /// Calculates the final market cap in SOL after all tokens are sold
-    ///
-    /// # Arguments
-    /// * `fee_basis_points` - Fee in basis points (1/100th of a percent)
-    pub fn get_final_market_cap_sol(&self, fee_basis_points: u64) -> u64 {
-        let total_sell_value: u128 =
-            self.get_buy_out_price(self.real_token_reserves, fee_basis_points) as u128;
-        let total_virtual_value: u128 = (self.virtual_sol_reserves as u128) + total_sell_value;
-        let total_virtual_tokens: u128 =
-            (self.virtual_token_reserves as u128) - (self.real_token_reserves as u128);
+   /// Calculates the final market cap in SOL after all tokens are sold
+   ///
+   /// # Arguments
+   /// * `fee_basis_points` - Fee in basis points (1/100th of a percent)
+   pub fn get_final_market_cap_sol(&self, fee_basis_points: u64) -> u64 {
+      let total_sell_value: u128 =
+         self.get_buy_out_price(self.real_token_reserves, fee_basis_points) as u128;
+      let total_virtual_value: u128 = (self.virtual_sol_reserves as u128) + total_sell_value;
+      let total_virtual_tokens: u128 =
+         (self.virtual_token_reserves as u128) - (self.real_token_reserves as u128);
 
-        if total_virtual_tokens == 0 {
-            return 0;
-        }
+      if total_virtual_tokens == 0 {
+         return 0;
+      }
 
-        ((self.token_total_supply as u128) * total_virtual_value / total_virtual_tokens) as u64
-    }
+      ((self.token_total_supply as u128) * total_virtual_value / total_virtual_tokens) as u64
+   }
 
-    /// Calculates the price to buy out all remaining tokens
-    ///
-    /// # Arguments
-    /// * `amount` - Amount of tokens to buy
-    /// * `fee_basis_points` - Fee in basis points (1/100th of a percent)
-    pub fn get_buy_out_price(&self, amount: u64, fee_basis_points: u64) -> u64 {
-        // Get the effective amount of sol tokens
-        let sol_tokens: u128 = if amount < self.real_sol_reserves {
-            self.real_sol_reserves as u128
-        } else {
-            amount as u128
-        };
+   /// Calculates the price to buy out all remaining tokens
+   ///
+   /// # Arguments
+   /// * `amount` - Amount of tokens to buy
+   /// * `fee_basis_points` - Fee in basis points (1/100th of a percent)
+   pub fn get_buy_out_price(&self, amount: u64, fee_basis_points: u64) -> u64 {
+      // Get the effective amount of sol tokens
+      let sol_tokens: u128 = if amount < self.real_sol_reserves {
+         self.real_sol_reserves as u128
+      } else {
+         amount as u128
+      };
 
-        // Calculate total sell value
-        let total_sell_value: u128 = (sol_tokens * (self.virtual_sol_reserves as u128))
-            / ((self.virtual_token_reserves as u128) - sol_tokens)
-            + 1;
+      // Calculate total sell value
+      let total_sell_value: u128 = (sol_tokens * (self.virtual_sol_reserves as u128))
+         / ((self.virtual_token_reserves as u128) - sol_tokens)
+         + 1;
 
-        // Calculate fee
-        let fee: u128 = (total_sell_value * (fee_basis_points as u128)) / 10000;
+      // Calculate fee
+      let fee: u128 = (total_sell_value * (fee_basis_points as u128)) / 10000;
 
-        // Return total including fee, converting back to u64
-        (total_sell_value + fee) as u64
-    }
+      // Return total including fee, converting back to u64
+      (total_sell_value + fee) as u64
+   }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+   use super::*;
 
-    fn get_bonding_curve() -> BondingCurveAccount {
-        BondingCurveAccount::new(
-            1,     // discriminator
-            1000,  // virtual_token_reserves
-            1000,  // virtual_sol_reserves
-            500,   // real_token_reserves
-            500,   // real_sol_reserves
-            1000,  // token_total_supply
-            false, // complete
-        )
-    }
+   fn get_bonding_curve() -> BondingCurveAccount {
+      BondingCurveAccount::new(
+         1,                    // discriminator
+         1000,                 // virtual_token_reserves
+         1000,                 // virtual_sol_reserves
+         500,                  // real_token_reserves
+         500,                  // real_sol_reserves
+         1000,                 // token_total_supply
+         false,                // complete
+         Pubkey::new_unique(), // creator
+      )
+   }
 
-    fn get_large_bonding_curve() -> BondingCurveAccount {
-        BondingCurveAccount::new(
-            1,            // discriminator
-            u64::MAX / 2, // virtual_token_reserves
-            u64::MAX / 2, // virtual_sol_reserves
-            u64::MAX / 4, // real_token_reserves
-            u64::MAX / 4, // real_sol_reserves
-            u64::MAX / 2, // token_total_supply
-            false,        // complete
-        )
-    }
+   fn get_large_bonding_curve() -> BondingCurveAccount {
+      BondingCurveAccount::new(
+         1,                    // discriminator
+         u64::MAX / 2,         // virtual_token_reserves
+         u64::MAX / 2,         // virtual_sol_reserves
+         u64::MAX / 4,         // real_token_reserves
+         u64::MAX / 4,         // real_sol_reserves
+         u64::MAX / 2,         // token_total_supply
+         false,                // complete
+         Pubkey::new_unique(), // creator
+      )
+   }
 
-    #[test]
-    fn test_bonding_curve_account() {
-        let bonding_curve: BondingCurveAccount = get_bonding_curve();
+   #[test]
+   fn test_bonding_curve_account() {
+      let bonding_curve: BondingCurveAccount = get_bonding_curve();
 
-        // Test buy price calculation
-        assert_eq!(bonding_curve.get_buy_price(0).unwrap(), 0);
+      // Test buy price calculation
+      assert_eq!(bonding_curve.get_buy_price(0).unwrap(), 0);
 
-        let buy_price = bonding_curve.get_buy_price(100).unwrap();
-        assert!(buy_price > 0);
-        assert!(buy_price <= bonding_curve.real_token_reserves);
+      let buy_price = bonding_curve.get_buy_price(100).unwrap();
+      assert!(buy_price > 0);
+      assert!(buy_price <= bonding_curve.real_token_reserves);
 
-        // Test sell price calculation
-        assert_eq!(bonding_curve.get_sell_price(0, 250).unwrap(), 0);
+      // Test sell price calculation
+      assert_eq!(bonding_curve.get_sell_price(0, 250).unwrap(), 0);
 
-        let sell_price = bonding_curve.get_sell_price(100, 250).unwrap();
-        assert!(sell_price > 0);
-    }
+      let sell_price = bonding_curve.get_sell_price(100, 250).unwrap();
+      assert!(sell_price > 0);
+   }
 
-    #[test]
-    fn test_bonding_curve_complete() {
-        let mut bonding_curve: BondingCurveAccount = get_bonding_curve();
+   #[test]
+   fn test_bonding_curve_complete() {
+      let mut bonding_curve: BondingCurveAccount = get_bonding_curve();
 
-        // Test operations work when not complete
-        assert!(bonding_curve.get_buy_price(100).is_ok());
-        assert!(bonding_curve.get_sell_price(100, 250).is_ok());
+      // Test operations work when not complete
+      assert!(bonding_curve.get_buy_price(100).is_ok());
+      assert!(bonding_curve.get_sell_price(100, 250).is_ok());
 
-        // Set curve to complete
-        bonding_curve.complete = true;
+      // Set curve to complete
+      bonding_curve.complete = true;
 
-        // Test operations fail when complete
-        assert!(bonding_curve.get_buy_price(100).is_err());
-        assert!(bonding_curve.get_sell_price(100, 250).is_err());
-    }
+      // Test operations fail when complete
+      assert!(bonding_curve.get_buy_price(100).is_err());
+      assert!(bonding_curve.get_sell_price(100, 250).is_err());
+   }
 
-    #[test]
-    fn test_market_cap_calculations() {
-        let bonding_curve: BondingCurveAccount = get_bonding_curve();
+   #[test]
+   fn test_market_cap_calculations() {
+      let bonding_curve: BondingCurveAccount = get_bonding_curve();
 
-        // Test market cap calculations
-        let market_cap = bonding_curve.get_market_cap_sol();
-        assert!(market_cap > 0);
+      // Test market cap calculations
+      let market_cap = bonding_curve.get_market_cap_sol();
+      assert!(market_cap > 0);
 
-        let final_market_cap = bonding_curve.get_final_market_cap_sol(250);
-        assert!(final_market_cap > 0);
-    }
+      let final_market_cap = bonding_curve.get_final_market_cap_sol(250);
+      assert!(final_market_cap > 0);
+   }
 
-    #[test]
-    fn test_buy_out_price() {
-        let bonding_curve: BondingCurveAccount = get_bonding_curve();
+   #[test]
+   fn test_buy_out_price() {
+      let bonding_curve: BondingCurveAccount = get_bonding_curve();
 
-        let buy_out_price = bonding_curve.get_buy_out_price(100, 250);
-        assert!(buy_out_price > 0);
+      let buy_out_price = bonding_curve.get_buy_out_price(100, 250);
+      assert!(buy_out_price > 0);
 
-        // Test with amount less than real_sol_reserves
-        let small_buy_out = bonding_curve.get_buy_out_price(400, 250);
-        assert!(small_buy_out > 0);
-    }
+      // Test with amount less than real_sol_reserves
+      let small_buy_out = bonding_curve.get_buy_out_price(400, 250);
+      assert!(small_buy_out > 0);
+   }
 
-    #[test]
-    fn test_overflow_buy_price() {
-        let bonding_curve = get_large_bonding_curve();
+   #[test]
+   fn test_overflow_buy_price() {
+      let bonding_curve = get_large_bonding_curve();
 
-        // Test buying with large SOL amount
-        let buy_price = bonding_curve.get_buy_price(u64::MAX).unwrap();
-        assert!(buy_price > 0);
-        assert!(buy_price <= bonding_curve.real_token_reserves);
-    }
+      // Test buying with large SOL amount
+      let buy_price = bonding_curve.get_buy_price(u64::MAX).unwrap();
+      assert!(buy_price > 0);
+      assert!(buy_price <= bonding_curve.real_token_reserves);
+   }
 
-    #[test]
-    fn test_overflow_sell_price() {
-        let bonding_curve = get_large_bonding_curve();
+   #[test]
+   fn test_overflow_sell_price() {
+      let bonding_curve = get_large_bonding_curve();
 
-        // Test selling large token amount
-        let sell_price = bonding_curve.get_sell_price(u64::MAX / 4, 250).unwrap();
-        assert!(sell_price > 0);
-    }
+      // Test selling large token amount
+      let sell_price = bonding_curve.get_sell_price(u64::MAX / 4, 250).unwrap();
+      assert!(sell_price > 0);
+   }
 
-    #[test]
-    fn test_overflow_market_cap() {
-        let bonding_curve = get_large_bonding_curve();
+   #[test]
+   fn test_overflow_market_cap() {
+      let bonding_curve = get_large_bonding_curve();
 
-        // Test market cap with large values
-        let market_cap = bonding_curve.get_market_cap_sol();
-        assert!(market_cap > 0);
+      // Test market cap with large values
+      let market_cap = bonding_curve.get_market_cap_sol();
+      assert!(market_cap > 0);
 
-        let final_market_cap = bonding_curve.get_final_market_cap_sol(250);
-        assert!(final_market_cap > 0);
-    }
+      let final_market_cap = bonding_curve.get_final_market_cap_sol(250);
+      assert!(final_market_cap > 0);
+   }
 
-    #[test]
-    fn test_overflow_buy_out_price() {
-        let bonding_curve = get_large_bonding_curve();
+   #[test]
+   fn test_overflow_buy_out_price() {
+      let bonding_curve = get_large_bonding_curve();
 
-        // Test buy out with large token amount
-        let buy_out_price = bonding_curve.get_buy_out_price(u64::MAX / 4, 250);
-        assert!(buy_out_price > 0);
-    }
+      // Test buy out with large token amount
+      let buy_out_price = bonding_curve.get_buy_out_price(u64::MAX / 4, 250);
+      assert!(buy_out_price > 0);
+   }
 }

--- a/src/accounts/bonding_curve.rs
+++ b/src/accounts/bonding_curve.rs
@@ -31,303 +31,303 @@ use solana_sdk::pubkey::Pubkey;
 /// Represents a bonding curve for token pricing and liquidity management
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct BondingCurveAccount {
-   /// Unique identifier for the bonding curve
-   pub discriminator: u64,
-   /// Virtual token reserves used for price calculations
-   pub virtual_token_reserves: u64,
-   /// Virtual SOL reserves used for price calculations
-   pub virtual_sol_reserves: u64,
-   /// Actual token reserves available for trading
-   pub real_token_reserves: u64,
-   /// Actual SOL reserves available for trading
-   pub real_sol_reserves: u64,
-   /// Total supply of tokens
-   pub token_total_supply: u64,
-   /// Whether the bonding curve is complete/finalized
-   pub complete: bool,
-   /// Token creator's address
-   pub creator: Pubkey,
+    /// Unique identifier for the bonding curve
+    pub discriminator: u64,
+    /// Virtual token reserves used for price calculations
+    pub virtual_token_reserves: u64,
+    /// Virtual SOL reserves used for price calculations
+    pub virtual_sol_reserves: u64,
+    /// Actual token reserves available for trading
+    pub real_token_reserves: u64,
+    /// Actual SOL reserves available for trading
+    pub real_sol_reserves: u64,
+    /// Total supply of tokens
+    pub token_total_supply: u64,
+    /// Whether the bonding curve is complete/finalized
+    pub complete: bool,
+    /// Token creator's address
+    pub creator: Pubkey,
 }
 
 impl BondingCurveAccount {
-   /// Creates a new bonding curve instance
-   ///
-   /// # Arguments
-   /// * `discriminator` - Unique identifier for the curve
-   /// * `virtual_token_reserves` - Virtual token reserves for price calculations
-   /// * `virtual_sol_reserves` - Virtual SOL reserves for price calculations
-   /// * `real_token_reserves` - Actual token reserves available
-   /// * `real_sol_reserves` - Actual SOL reserves available
-   /// * `token_total_supply` - Total supply of tokens
-   /// * `complete` - Whether the curve is complete
-   pub fn new(
-      discriminator: u64,
-      virtual_token_reserves: u64,
-      virtual_sol_reserves: u64,
-      real_token_reserves: u64,
-      real_sol_reserves: u64,
-      token_total_supply: u64,
-      complete: bool,
-      creator: Pubkey,
-   ) -> Self {
-      Self {
-         discriminator,
-         virtual_token_reserves,
-         virtual_sol_reserves,
-         real_token_reserves,
-         real_sol_reserves,
-         token_total_supply,
-         complete,
-         creator,
-      }
-   }
+    /// Creates a new bonding curve instance
+    ///
+    /// # Arguments
+    /// * `discriminator` - Unique identifier for the curve
+    /// * `virtual_token_reserves` - Virtual token reserves for price calculations
+    /// * `virtual_sol_reserves` - Virtual SOL reserves for price calculations
+    /// * `real_token_reserves` - Actual token reserves available
+    /// * `real_sol_reserves` - Actual SOL reserves available
+    /// * `token_total_supply` - Total supply of tokens
+    /// * `complete` - Whether the curve is complete
+    pub fn new(
+        discriminator: u64,
+        virtual_token_reserves: u64,
+        virtual_sol_reserves: u64,
+        real_token_reserves: u64,
+        real_sol_reserves: u64,
+        token_total_supply: u64,
+        complete: bool,
+        creator: Pubkey,
+    ) -> Self {
+        Self {
+            discriminator,
+            virtual_token_reserves,
+            virtual_sol_reserves,
+            real_token_reserves,
+            real_sol_reserves,
+            token_total_supply,
+            complete,
+            creator,
+        }
+    }
 
-   /// Calculates the amount of tokens received for a given SOL amount
-   ///
-   /// # Arguments
-   /// * `amount` - Amount of SOL to spend
-   ///
-   /// # Returns
-   /// * `Ok(u64)` - Amount of tokens that would be received
-   /// * `Err(&str)` - Error message if curve is complete
-   pub fn get_buy_price(&self, amount: u64) -> Result<u64, &'static str> {
-      if self.complete {
-         return Err("Curve is complete");
-      }
+    /// Calculates the amount of tokens received for a given SOL amount
+    ///
+    /// # Arguments
+    /// * `amount` - Amount of SOL to spend
+    ///
+    /// # Returns
+    /// * `Ok(u64)` - Amount of tokens that would be received
+    /// * `Err(&str)` - Error message if curve is complete
+    pub fn get_buy_price(&self, amount: u64) -> Result<u64, &'static str> {
+        if self.complete {
+            return Err("Curve is complete");
+        }
 
-      if amount == 0 {
-         return Ok(0);
-      }
+        if amount == 0 {
+            return Ok(0);
+        }
 
-      // Calculate the product of virtual reserves using u128 to avoid overflow
-      let n: u128 = (self.virtual_sol_reserves as u128) * (self.virtual_token_reserves as u128);
+        // Calculate the product of virtual reserves using u128 to avoid overflow
+        let n: u128 = (self.virtual_sol_reserves as u128) * (self.virtual_token_reserves as u128);
 
-      // Calculate the new virtual sol reserves after the purchase
-      let i: u128 = (self.virtual_sol_reserves as u128) + (amount as u128);
+        // Calculate the new virtual sol reserves after the purchase
+        let i: u128 = (self.virtual_sol_reserves as u128) + (amount as u128);
 
-      // Calculate the new virtual token reserves after the purchase
-      let r: u128 = n / i + 1;
+        // Calculate the new virtual token reserves after the purchase
+        let r: u128 = n / i + 1;
 
-      // Calculate the amount of tokens to be purchased
-      let s: u128 = (self.virtual_token_reserves as u128) - r;
+        // Calculate the amount of tokens to be purchased
+        let s: u128 = (self.virtual_token_reserves as u128) - r;
 
-      // Convert back to u64 and return the minimum of calculated tokens and real reserves
-      let s_u64 = s as u64;
-      Ok(if s_u64 < self.real_token_reserves {
-         s_u64
-      } else {
-         self.real_token_reserves
-      })
-   }
+        // Convert back to u64 and return the minimum of calculated tokens and real reserves
+        let s_u64 = s as u64;
+        Ok(if s_u64 < self.real_token_reserves {
+            s_u64
+        } else {
+            self.real_token_reserves
+        })
+    }
 
-   /// Calculates the amount of SOL received for selling tokens
-   ///
-   /// # Arguments
-   /// * `amount` - Amount of tokens to sell
-   /// * `fee_basis_points` - Fee in basis points (1/100th of a percent)
-   ///
-   /// # Returns
-   /// * `Ok(u64)` - Amount of SOL that would be received after fees
-   /// * `Err(&str)` - Error message if curve is complete
-   pub fn get_sell_price(&self, amount: u64, fee_basis_points: u64) -> Result<u64, &'static str> {
-      if self.complete {
-         return Err("Curve is complete");
-      }
+    /// Calculates the amount of SOL received for selling tokens
+    ///
+    /// # Arguments
+    /// * `amount` - Amount of tokens to sell
+    /// * `fee_basis_points` - Fee in basis points (1/100th of a percent)
+    ///
+    /// # Returns
+    /// * `Ok(u64)` - Amount of SOL that would be received after fees
+    /// * `Err(&str)` - Error message if curve is complete
+    pub fn get_sell_price(&self, amount: u64, fee_basis_points: u64) -> Result<u64, &'static str> {
+        if self.complete {
+            return Err("Curve is complete");
+        }
 
-      if amount == 0 {
-         return Ok(0);
-      }
+        if amount == 0 {
+            return Ok(0);
+        }
 
-      // Calculate the proportional amount of virtual sol reserves to be received using u128
-      let n: u128 = ((amount as u128) * (self.virtual_sol_reserves as u128))
-         / ((self.virtual_token_reserves as u128) + (amount as u128));
+        // Calculate the proportional amount of virtual sol reserves to be received using u128
+        let n: u128 = ((amount as u128) * (self.virtual_sol_reserves as u128))
+            / ((self.virtual_token_reserves as u128) + (amount as u128));
 
-      // Calculate the fee amount in the same units
-      let a: u128 = (n * (fee_basis_points as u128)) / 10000;
+        // Calculate the fee amount in the same units
+        let a: u128 = (n * (fee_basis_points as u128)) / 10000;
 
-      // Return the net amount after deducting the fee, converting back to u64
-      Ok((n - a) as u64)
-   }
+        // Return the net amount after deducting the fee, converting back to u64
+        Ok((n - a) as u64)
+    }
 
-   /// Calculates the current market cap in SOL
-   pub fn get_market_cap_sol(&self) -> u64 {
-      if self.virtual_token_reserves == 0 {
-         return 0;
-      }
+    /// Calculates the current market cap in SOL
+    pub fn get_market_cap_sol(&self) -> u64 {
+        if self.virtual_token_reserves == 0 {
+            return 0;
+        }
 
-      ((self.token_total_supply as u128) * (self.virtual_sol_reserves as u128)
-         / (self.virtual_token_reserves as u128)) as u64
-   }
+        ((self.token_total_supply as u128) * (self.virtual_sol_reserves as u128)
+            / (self.virtual_token_reserves as u128)) as u64
+    }
 
-   /// Calculates the final market cap in SOL after all tokens are sold
-   ///
-   /// # Arguments
-   /// * `fee_basis_points` - Fee in basis points (1/100th of a percent)
-   pub fn get_final_market_cap_sol(&self, fee_basis_points: u64) -> u64 {
-      let total_sell_value: u128 =
-         self.get_buy_out_price(self.real_token_reserves, fee_basis_points) as u128;
-      let total_virtual_value: u128 = (self.virtual_sol_reserves as u128) + total_sell_value;
-      let total_virtual_tokens: u128 =
-         (self.virtual_token_reserves as u128) - (self.real_token_reserves as u128);
+    /// Calculates the final market cap in SOL after all tokens are sold
+    ///
+    /// # Arguments
+    /// * `fee_basis_points` - Fee in basis points (1/100th of a percent)
+    pub fn get_final_market_cap_sol(&self, fee_basis_points: u64) -> u64 {
+        let total_sell_value: u128 =
+            self.get_buy_out_price(self.real_token_reserves, fee_basis_points) as u128;
+        let total_virtual_value: u128 = (self.virtual_sol_reserves as u128) + total_sell_value;
+        let total_virtual_tokens: u128 =
+            (self.virtual_token_reserves as u128) - (self.real_token_reserves as u128);
 
-      if total_virtual_tokens == 0 {
-         return 0;
-      }
+        if total_virtual_tokens == 0 {
+            return 0;
+        }
 
-      ((self.token_total_supply as u128) * total_virtual_value / total_virtual_tokens) as u64
-   }
+        ((self.token_total_supply as u128) * total_virtual_value / total_virtual_tokens) as u64
+    }
 
-   /// Calculates the price to buy out all remaining tokens
-   ///
-   /// # Arguments
-   /// * `amount` - Amount of tokens to buy
-   /// * `fee_basis_points` - Fee in basis points (1/100th of a percent)
-   pub fn get_buy_out_price(&self, amount: u64, fee_basis_points: u64) -> u64 {
-      // Get the effective amount of sol tokens
-      let sol_tokens: u128 = if amount < self.real_sol_reserves {
-         self.real_sol_reserves as u128
-      } else {
-         amount as u128
-      };
+    /// Calculates the price to buy out all remaining tokens
+    ///
+    /// # Arguments
+    /// * `amount` - Amount of tokens to buy
+    /// * `fee_basis_points` - Fee in basis points (1/100th of a percent)
+    pub fn get_buy_out_price(&self, amount: u64, fee_basis_points: u64) -> u64 {
+        // Get the effective amount of sol tokens
+        let sol_tokens: u128 = if amount < self.real_sol_reserves {
+            self.real_sol_reserves as u128
+        } else {
+            amount as u128
+        };
 
-      // Calculate total sell value
-      let total_sell_value: u128 = (sol_tokens * (self.virtual_sol_reserves as u128))
-         / ((self.virtual_token_reserves as u128) - sol_tokens)
-         + 1;
+        // Calculate total sell value
+        let total_sell_value: u128 = (sol_tokens * (self.virtual_sol_reserves as u128))
+            / ((self.virtual_token_reserves as u128) - sol_tokens)
+            + 1;
 
-      // Calculate fee
-      let fee: u128 = (total_sell_value * (fee_basis_points as u128)) / 10000;
+        // Calculate fee
+        let fee: u128 = (total_sell_value * (fee_basis_points as u128)) / 10000;
 
-      // Return total including fee, converting back to u64
-      (total_sell_value + fee) as u64
-   }
+        // Return total including fee, converting back to u64
+        (total_sell_value + fee) as u64
+    }
 }
 
 #[cfg(test)]
 mod tests {
-   use super::*;
+    use super::*;
 
-   fn get_bonding_curve() -> BondingCurveAccount {
-      BondingCurveAccount::new(
-         1,                    // discriminator
-         1000,                 // virtual_token_reserves
-         1000,                 // virtual_sol_reserves
-         500,                  // real_token_reserves
-         500,                  // real_sol_reserves
-         1000,                 // token_total_supply
-         false,                // complete
-         Pubkey::new_unique(), // creator
-      )
-   }
+    fn get_bonding_curve() -> BondingCurveAccount {
+        BondingCurveAccount::new(
+            1,                    // discriminator
+            1000,                 // virtual_token_reserves
+            1000,                 // virtual_sol_reserves
+            500,                  // real_token_reserves
+            500,                  // real_sol_reserves
+            1000,                 // token_total_supply
+            false,                // complete
+            Pubkey::new_unique(), // creator
+        )
+    }
 
-   fn get_large_bonding_curve() -> BondingCurveAccount {
-      BondingCurveAccount::new(
-         1,                    // discriminator
-         u64::MAX / 2,         // virtual_token_reserves
-         u64::MAX / 2,         // virtual_sol_reserves
-         u64::MAX / 4,         // real_token_reserves
-         u64::MAX / 4,         // real_sol_reserves
-         u64::MAX / 2,         // token_total_supply
-         false,                // complete
-         Pubkey::new_unique(), // creator
-      )
-   }
+    fn get_large_bonding_curve() -> BondingCurveAccount {
+        BondingCurveAccount::new(
+            1,                    // discriminator
+            u64::MAX / 2,         // virtual_token_reserves
+            u64::MAX / 2,         // virtual_sol_reserves
+            u64::MAX / 4,         // real_token_reserves
+            u64::MAX / 4,         // real_sol_reserves
+            u64::MAX / 2,         // token_total_supply
+            false,                // complete
+            Pubkey::new_unique(), // creator
+        )
+    }
 
-   #[test]
-   fn test_bonding_curve_account() {
-      let bonding_curve: BondingCurveAccount = get_bonding_curve();
+    #[test]
+    fn test_bonding_curve_account() {
+        let bonding_curve: BondingCurveAccount = get_bonding_curve();
 
-      // Test buy price calculation
-      assert_eq!(bonding_curve.get_buy_price(0).unwrap(), 0);
+        // Test buy price calculation
+        assert_eq!(bonding_curve.get_buy_price(0).unwrap(), 0);
 
-      let buy_price = bonding_curve.get_buy_price(100).unwrap();
-      assert!(buy_price > 0);
-      assert!(buy_price <= bonding_curve.real_token_reserves);
+        let buy_price = bonding_curve.get_buy_price(100).unwrap();
+        assert!(buy_price > 0);
+        assert!(buy_price <= bonding_curve.real_token_reserves);
 
-      // Test sell price calculation
-      assert_eq!(bonding_curve.get_sell_price(0, 250).unwrap(), 0);
+        // Test sell price calculation
+        assert_eq!(bonding_curve.get_sell_price(0, 250).unwrap(), 0);
 
-      let sell_price = bonding_curve.get_sell_price(100, 250).unwrap();
-      assert!(sell_price > 0);
-   }
+        let sell_price = bonding_curve.get_sell_price(100, 250).unwrap();
+        assert!(sell_price > 0);
+    }
 
-   #[test]
-   fn test_bonding_curve_complete() {
-      let mut bonding_curve: BondingCurveAccount = get_bonding_curve();
+    #[test]
+    fn test_bonding_curve_complete() {
+        let mut bonding_curve: BondingCurveAccount = get_bonding_curve();
 
-      // Test operations work when not complete
-      assert!(bonding_curve.get_buy_price(100).is_ok());
-      assert!(bonding_curve.get_sell_price(100, 250).is_ok());
+        // Test operations work when not complete
+        assert!(bonding_curve.get_buy_price(100).is_ok());
+        assert!(bonding_curve.get_sell_price(100, 250).is_ok());
 
-      // Set curve to complete
-      bonding_curve.complete = true;
+        // Set curve to complete
+        bonding_curve.complete = true;
 
-      // Test operations fail when complete
-      assert!(bonding_curve.get_buy_price(100).is_err());
-      assert!(bonding_curve.get_sell_price(100, 250).is_err());
-   }
+        // Test operations fail when complete
+        assert!(bonding_curve.get_buy_price(100).is_err());
+        assert!(bonding_curve.get_sell_price(100, 250).is_err());
+    }
 
-   #[test]
-   fn test_market_cap_calculations() {
-      let bonding_curve: BondingCurveAccount = get_bonding_curve();
+    #[test]
+    fn test_market_cap_calculations() {
+        let bonding_curve: BondingCurveAccount = get_bonding_curve();
 
-      // Test market cap calculations
-      let market_cap = bonding_curve.get_market_cap_sol();
-      assert!(market_cap > 0);
+        // Test market cap calculations
+        let market_cap = bonding_curve.get_market_cap_sol();
+        assert!(market_cap > 0);
 
-      let final_market_cap = bonding_curve.get_final_market_cap_sol(250);
-      assert!(final_market_cap > 0);
-   }
+        let final_market_cap = bonding_curve.get_final_market_cap_sol(250);
+        assert!(final_market_cap > 0);
+    }
 
-   #[test]
-   fn test_buy_out_price() {
-      let bonding_curve: BondingCurveAccount = get_bonding_curve();
+    #[test]
+    fn test_buy_out_price() {
+        let bonding_curve: BondingCurveAccount = get_bonding_curve();
 
-      let buy_out_price = bonding_curve.get_buy_out_price(100, 250);
-      assert!(buy_out_price > 0);
+        let buy_out_price = bonding_curve.get_buy_out_price(100, 250);
+        assert!(buy_out_price > 0);
 
-      // Test with amount less than real_sol_reserves
-      let small_buy_out = bonding_curve.get_buy_out_price(400, 250);
-      assert!(small_buy_out > 0);
-   }
+        // Test with amount less than real_sol_reserves
+        let small_buy_out = bonding_curve.get_buy_out_price(400, 250);
+        assert!(small_buy_out > 0);
+    }
 
-   #[test]
-   fn test_overflow_buy_price() {
-      let bonding_curve = get_large_bonding_curve();
+    #[test]
+    fn test_overflow_buy_price() {
+        let bonding_curve = get_large_bonding_curve();
 
-      // Test buying with large SOL amount
-      let buy_price = bonding_curve.get_buy_price(u64::MAX).unwrap();
-      assert!(buy_price > 0);
-      assert!(buy_price <= bonding_curve.real_token_reserves);
-   }
+        // Test buying with large SOL amount
+        let buy_price = bonding_curve.get_buy_price(u64::MAX).unwrap();
+        assert!(buy_price > 0);
+        assert!(buy_price <= bonding_curve.real_token_reserves);
+    }
 
-   #[test]
-   fn test_overflow_sell_price() {
-      let bonding_curve = get_large_bonding_curve();
+    #[test]
+    fn test_overflow_sell_price() {
+        let bonding_curve = get_large_bonding_curve();
 
-      // Test selling large token amount
-      let sell_price = bonding_curve.get_sell_price(u64::MAX / 4, 250).unwrap();
-      assert!(sell_price > 0);
-   }
+        // Test selling large token amount
+        let sell_price = bonding_curve.get_sell_price(u64::MAX / 4, 250).unwrap();
+        assert!(sell_price > 0);
+    }
 
-   #[test]
-   fn test_overflow_market_cap() {
-      let bonding_curve = get_large_bonding_curve();
+    #[test]
+    fn test_overflow_market_cap() {
+        let bonding_curve = get_large_bonding_curve();
 
-      // Test market cap with large values
-      let market_cap = bonding_curve.get_market_cap_sol();
-      assert!(market_cap > 0);
+        // Test market cap with large values
+        let market_cap = bonding_curve.get_market_cap_sol();
+        assert!(market_cap > 0);
 
-      let final_market_cap = bonding_curve.get_final_market_cap_sol(250);
-      assert!(final_market_cap > 0);
-   }
+        let final_market_cap = bonding_curve.get_final_market_cap_sol(250);
+        assert!(final_market_cap > 0);
+    }
 
-   #[test]
-   fn test_overflow_buy_out_price() {
-      let bonding_curve = get_large_bonding_curve();
+    #[test]
+    fn test_overflow_buy_out_price() {
+        let bonding_curve = get_large_bonding_curve();
 
-      // Test buy out with large token amount
-      let buy_out_price = bonding_curve.get_buy_out_price(u64::MAX / 4, 250);
-      assert!(buy_out_price > 0);
-   }
+        // Test buy out with large token amount
+        let buy_out_price = bonding_curve.get_buy_out_price(u64::MAX / 4, 250);
+        assert!(buy_out_price > 0);
+    }
 }

--- a/src/accounts/bonding_curve.rs
+++ b/src/accounts/bonding_curve.rs
@@ -60,6 +60,7 @@ impl BondingCurveAccount {
     /// * `real_sol_reserves` - Actual SOL reserves available
     /// * `token_total_supply` - Total supply of tokens
     /// * `complete` - Whether the curve is complete
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         discriminator: u64,
         virtual_token_reserves: u64,

--- a/src/accounts/global.rs
+++ b/src/accounts/global.rs
@@ -34,208 +34,215 @@ use solana_sdk::pubkey::Pubkey;
 /// Represents the global configuration account for token pricing and fees
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct GlobalAccount {
-    /// Unique identifier for the global account
-    pub discriminator: u64,
-    /// Whether the global account has been initialized
-    pub initialized: bool,
-    /// Authority that can modify global settings
-    pub authority: Pubkey,
-    /// Account that receives fees
-    pub fee_recipient: Pubkey,
-    /// Initial virtual token reserves for price calculations
-    pub initial_virtual_token_reserves: u64,
-    /// Initial virtual SOL reserves for price calculations
-    pub initial_virtual_sol_reserves: u64,
-    /// Initial actual token reserves available for trading
-    pub initial_real_token_reserves: u64,
-    /// Total supply of tokens
-    pub token_total_supply: u64,
-    /// Fee in basis points (1/100th of a percent)
-    pub fee_basis_points: u64,
-    /// Authority that can withdraw funds
-    pub withdraw_authority: Pubkey,
-    /// Flag to enable pool migration
-    pub enable_migrate: bool,
-    /// Fee for migrating pools
-    pub pool_migration_fee: u64,
-    /// Fee for creators
-    pub creator_fee: u64,
-    /// Array of public keys for fee recipients
-    pub fee_recipients: [Pubkey; 7],
+   /// Unique identifier for the global account
+   pub discriminator: u64,
+   /// Whether the global account has been initialized
+   pub initialized: bool,
+   /// Authority that can modify global settings
+   pub authority: Pubkey,
+   /// Account that receives fees
+   pub fee_recipient: Pubkey,
+   /// Initial virtual token reserves for price calculations
+   pub initial_virtual_token_reserves: u64,
+   /// Initial virtual SOL reserves for price calculations
+   pub initial_virtual_sol_reserves: u64,
+   /// Initial actual token reserves available for trading
+   pub initial_real_token_reserves: u64,
+   /// Total supply of tokens
+   pub token_total_supply: u64,
+   /// Fee in basis points (1/100th of a percent)
+   pub fee_basis_points: u64,
+   /// Authority that can withdraw funds
+   pub withdraw_authority: Pubkey,
+   /// Flag to enable pool migration
+   pub enable_migrate: bool,
+   /// Fee for migrating pools
+   pub pool_migration_fee: u64,
+   /// Fee for creators in base points
+   pub creator_fee_basis_points: u64,
+   /// Array of public keys for fee recipients
+   pub fee_recipients: [Pubkey; 7],
+   /// Authority that sets the creator of the token
+   pub set_creator_authority: Pubkey,
 }
 
 impl GlobalAccount {
-    /// Creates a new global account instance
-    ///
-    /// # Arguments
-    /// * `discriminator` - Unique identifier for the account
-    /// * `initialized` - Whether the account is initialized
-    /// * `authority` - Authority pubkey that can modify settings
-    /// * `fee_recipient` - Account that receives fees
-    /// * `initial_virtual_token_reserves` - Initial virtual token reserves
-    /// * `initial_virtual_sol_reserves` - Initial virtual SOL reserves
-    /// * `initial_real_token_reserves` - Initial actual token reserves
-    /// * `token_total_supply` - Total supply of tokens
-    /// * `fee_basis_points` - Fee in basis points
-    /// * `withdraw_authority` - Authority that can withdraw funds
-    /// * `enable_migrate` - Flag to enable pool migration
-    /// * `pool_migration_fee` - Fee for migrating pools
-    /// * `creator_fee` - Fee for creators
-    /// * `fee_recipients` - Array of public keys for fee recipients
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        discriminator: u64,
-        initialized: bool,
-        authority: Pubkey,
-        fee_recipient: Pubkey,
-        initial_virtual_token_reserves: u64,
-        initial_virtual_sol_reserves: u64,
-        initial_real_token_reserves: u64,
-        token_total_supply: u64,
-        fee_basis_points: u64,
-        withdraw_authority: Pubkey,
-        enable_migrate: bool,
-        pool_migration_fee: u64,
-        creator_fee: u64,
-        fee_recipients: [Pubkey; 7],
-    ) -> Self {
-        Self {
-            discriminator,
-            initialized,
-            authority,
-            fee_recipient,
-            initial_virtual_token_reserves,
-            initial_virtual_sol_reserves,
-            initial_real_token_reserves,
-            token_total_supply,
-            fee_basis_points,
-            withdraw_authority,
-            enable_migrate,
-            pool_migration_fee,
-            creator_fee,
-            fee_recipients,
-        }
-    }
+   /// Creates a new global account instance
+   ///
+   /// # Arguments
+   /// * `discriminator` - Unique identifier for the account
+   /// * `initialized` - Whether the account is initialized
+   /// * `authority` - Authority pubkey that can modify settings
+   /// * `fee_recipient` - Account that receives fees
+   /// * `initial_virtual_token_reserves` - Initial virtual token reserves
+   /// * `initial_virtual_sol_reserves` - Initial virtual SOL reserves
+   /// * `initial_real_token_reserves` - Initial actual token reserves
+   /// * `token_total_supply` - Total supply of tokens
+   /// * `fee_basis_points` - Fee in basis points
+   /// * `withdraw_authority` - Authority that can withdraw funds
+   /// * `enable_migrate` - Flag to enable pool migration
+   /// * `pool_migration_fee` - Fee for migrating pools
+   /// * `creator_fee_basis_points` - Fee for creators in base points
+   /// * `fee_recipients` - Array of public keys for fee recipients
+   /// * `set_creator_authority` - Authority that sets the creator of the token
+   #[allow(clippy::too_many_arguments)]
+   pub fn new(
+      discriminator: u64,
+      initialized: bool,
+      authority: Pubkey,
+      fee_recipient: Pubkey,
+      initial_virtual_token_reserves: u64,
+      initial_virtual_sol_reserves: u64,
+      initial_real_token_reserves: u64,
+      token_total_supply: u64,
+      fee_basis_points: u64,
+      withdraw_authority: Pubkey,
+      enable_migrate: bool,
+      pool_migration_fee: u64,
+      creator_fee_basis_points: u64,
+      fee_recipients: [Pubkey; 7],
+      set_creator_authority: Pubkey,
+   ) -> Self {
+      Self {
+         discriminator,
+         initialized,
+         authority,
+         fee_recipient,
+         initial_virtual_token_reserves,
+         initial_virtual_sol_reserves,
+         initial_real_token_reserves,
+         token_total_supply,
+         fee_basis_points,
+         withdraw_authority,
+         enable_migrate,
+         pool_migration_fee,
+         creator_fee_basis_points,
+         fee_recipients,
+         set_creator_authority,
+      }
+   }
 
-    /// Calculates the initial amount of tokens received for a given SOL amount
-    ///
-    /// # Arguments
-    /// * `amount` - Amount of SOL to spend
-    ///
-    /// # Returns
-    /// Amount of tokens that would be received
-    pub fn get_initial_buy_price(&self, amount: u64) -> u64 {
-        if amount == 0 {
-            return 0;
-        }
+   /// Calculates the initial amount of tokens received for a given SOL amount
+   ///
+   /// # Arguments
+   /// * `amount` - Amount of SOL to spend
+   ///
+   /// # Returns
+   /// Amount of tokens that would be received
+   pub fn get_initial_buy_price(&self, amount: u64) -> u64 {
+      if amount == 0 {
+         return 0;
+      }
 
-        let n: u128 = (self.initial_virtual_sol_reserves as u128)
-            * (self.initial_virtual_token_reserves as u128);
-        let i: u128 = (self.initial_virtual_sol_reserves as u128) + (amount as u128);
-        let r: u128 = n / i + 1;
-        let s: u128 = (self.initial_virtual_token_reserves as u128) - r;
+      let n: u128 = (self.initial_virtual_sol_reserves as u128)
+         * (self.initial_virtual_token_reserves as u128);
+      let i: u128 = (self.initial_virtual_sol_reserves as u128) + (amount as u128);
+      let r: u128 = n / i + 1;
+      let s: u128 = (self.initial_virtual_token_reserves as u128) - r;
 
-        if s < (self.initial_real_token_reserves as u128) {
-            s as u64
-        } else {
-            self.initial_real_token_reserves
-        }
-    }
+      if s < (self.initial_real_token_reserves as u128) {
+         s as u64
+      } else {
+         self.initial_real_token_reserves
+      }
+   }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+   use super::*;
 
-    fn get_global() -> GlobalAccount {
-        GlobalAccount::new(
-            1,
-            true,
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            1000,
-            1000,
-            500,
-            1000,
-            250,
-            Pubkey::new_unique(),
-            true,
-            100,
-            0,
-            [Pubkey::new_unique(); 7],
-        )
-    }
+   fn get_global() -> GlobalAccount {
+      GlobalAccount::new(
+         1,
+         true,
+         Pubkey::new_unique(),
+         Pubkey::new_unique(),
+         1000,
+         1000,
+         500,
+         1000,
+         250,
+         Pubkey::new_unique(),
+         true,
+         100,
+         0,
+         [Pubkey::new_unique(); 7],
+         Pubkey::new_unique(),
+      )
+   }
 
-    fn get_large_global() -> GlobalAccount {
-        GlobalAccount::new(
-            1,
-            true,
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            u64::MAX,
-            u64::MAX,
-            u64::MAX / 2,
-            u64::MAX,
-            250,
-            Pubkey::new_unique(),
-            true,
-            u64::MAX,
-            u64::MAX,
-            [Pubkey::new_unique(); 7],
-        )
-    }
+   fn get_large_global() -> GlobalAccount {
+      GlobalAccount::new(
+         1,
+         true,
+         Pubkey::new_unique(),
+         Pubkey::new_unique(),
+         u64::MAX,
+         u64::MAX,
+         u64::MAX / 2,
+         u64::MAX,
+         250,
+         Pubkey::new_unique(),
+         true,
+         u64::MAX,
+         u64::MAX,
+         [Pubkey::new_unique(); 7],
+         Pubkey::new_unique(),
+      )
+   }
 
-    #[test]
-    fn test_global_account() {
-        let global: GlobalAccount = get_global();
+   #[test]
+   fn test_global_account() {
+      let global: GlobalAccount = get_global();
 
-        // Test initial buy price calculation
-        assert_eq!(global.get_initial_buy_price(0), 0);
+      // Test initial buy price calculation
+      assert_eq!(global.get_initial_buy_price(0), 0);
 
-        let price: u64 = global.get_initial_buy_price(100);
-        assert!(price > 0);
-        assert!(price <= global.initial_real_token_reserves);
-    }
+      let price: u64 = global.get_initial_buy_price(100);
+      assert!(price > 0);
+      assert!(price <= global.initial_real_token_reserves);
+   }
 
-    #[test]
-    fn test_global_account_max_reserves() {
-        let mut global: GlobalAccount = get_global();
-        global.initial_real_token_reserves = 100;
+   #[test]
+   fn test_global_account_max_reserves() {
+      let mut global: GlobalAccount = get_global();
+      global.initial_real_token_reserves = 100;
 
-        // Test that returned amount is capped by real_token_reserves
-        let price: u64 = global.get_initial_buy_price(1000);
-        assert_eq!(price, global.initial_real_token_reserves);
-    }
+      // Test that returned amount is capped by real_token_reserves
+      let price: u64 = global.get_initial_buy_price(1000);
+      assert_eq!(price, global.initial_real_token_reserves);
+   }
 
-    #[test]
-    fn test_global_account_overflow() {
-        let global: GlobalAccount = get_large_global();
+   #[test]
+   fn test_global_account_overflow() {
+      let global: GlobalAccount = get_large_global();
 
-        // Test with maximum possible SOL amount
-        let price: u64 = global.get_initial_buy_price(u64::MAX);
-        assert!(price > 0);
-        assert!(price <= global.initial_real_token_reserves);
+      // Test with maximum possible SOL amount
+      let price: u64 = global.get_initial_buy_price(u64::MAX);
+      assert!(price > 0);
+      assert!(price <= global.initial_real_token_reserves);
 
-        // Test with large but not maximum SOL amount
-        let price: u64 = global.get_initial_buy_price(u64::MAX / 2);
-        assert!(price > 0);
-        assert!(price <= global.initial_real_token_reserves);
-    }
+      // Test with large but not maximum SOL amount
+      let price: u64 = global.get_initial_buy_price(u64::MAX / 2);
+      assert!(price > 0);
+      assert!(price <= global.initial_real_token_reserves);
+   }
 
-    #[test]
-    fn test_global_account_overflow_edge_cases() {
-        let mut global: GlobalAccount = get_large_global();
-        global.initial_virtual_sol_reserves = u64::MAX - 1000;
-        global.initial_virtual_token_reserves = u64::MAX - 1000;
-        global.initial_real_token_reserves = u64::MAX / 4;
+   #[test]
+   fn test_global_account_overflow_edge_cases() {
+      let mut global: GlobalAccount = get_large_global();
+      global.initial_virtual_sol_reserves = u64::MAX - 1000;
+      global.initial_virtual_token_reserves = u64::MAX - 1000;
+      global.initial_real_token_reserves = u64::MAX / 4;
 
-        // Test with amounts near u64::MAX
-        let price: u64 = global.get_initial_buy_price(u64::MAX - 1);
-        assert!(price > 0);
-        assert!(price <= global.initial_real_token_reserves);
+      // Test with amounts near u64::MAX
+      let price: u64 = global.get_initial_buy_price(u64::MAX - 1);
+      assert!(price > 0);
+      assert!(price <= global.initial_real_token_reserves);
 
-        let price: u64 = global.get_initial_buy_price(u64::MAX - 1000);
-        assert!(price > 0);
-        assert!(price <= global.initial_real_token_reserves);
-    }
+      let price: u64 = global.get_initial_buy_price(u64::MAX - 1000);
+      assert!(price > 0);
+      assert!(price <= global.initial_real_token_reserves);
+   }
 }

--- a/src/accounts/global.rs
+++ b/src/accounts/global.rs
@@ -34,215 +34,215 @@ use solana_sdk::pubkey::Pubkey;
 /// Represents the global configuration account for token pricing and fees
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct GlobalAccount {
-   /// Unique identifier for the global account
-   pub discriminator: u64,
-   /// Whether the global account has been initialized
-   pub initialized: bool,
-   /// Authority that can modify global settings
-   pub authority: Pubkey,
-   /// Account that receives fees
-   pub fee_recipient: Pubkey,
-   /// Initial virtual token reserves for price calculations
-   pub initial_virtual_token_reserves: u64,
-   /// Initial virtual SOL reserves for price calculations
-   pub initial_virtual_sol_reserves: u64,
-   /// Initial actual token reserves available for trading
-   pub initial_real_token_reserves: u64,
-   /// Total supply of tokens
-   pub token_total_supply: u64,
-   /// Fee in basis points (1/100th of a percent)
-   pub fee_basis_points: u64,
-   /// Authority that can withdraw funds
-   pub withdraw_authority: Pubkey,
-   /// Flag to enable pool migration
-   pub enable_migrate: bool,
-   /// Fee for migrating pools
-   pub pool_migration_fee: u64,
-   /// Fee for creators in base points
-   pub creator_fee_basis_points: u64,
-   /// Array of public keys for fee recipients
-   pub fee_recipients: [Pubkey; 7],
-   /// Authority that sets the creator of the token
-   pub set_creator_authority: Pubkey,
+    /// Unique identifier for the global account
+    pub discriminator: u64,
+    /// Whether the global account has been initialized
+    pub initialized: bool,
+    /// Authority that can modify global settings
+    pub authority: Pubkey,
+    /// Account that receives fees
+    pub fee_recipient: Pubkey,
+    /// Initial virtual token reserves for price calculations
+    pub initial_virtual_token_reserves: u64,
+    /// Initial virtual SOL reserves for price calculations
+    pub initial_virtual_sol_reserves: u64,
+    /// Initial actual token reserves available for trading
+    pub initial_real_token_reserves: u64,
+    /// Total supply of tokens
+    pub token_total_supply: u64,
+    /// Fee in basis points (1/100th of a percent)
+    pub fee_basis_points: u64,
+    /// Authority that can withdraw funds
+    pub withdraw_authority: Pubkey,
+    /// Flag to enable pool migration
+    pub enable_migrate: bool,
+    /// Fee for migrating pools
+    pub pool_migration_fee: u64,
+    /// Fee for creators in base points
+    pub creator_fee_basis_points: u64,
+    /// Array of public keys for fee recipients
+    pub fee_recipients: [Pubkey; 7],
+    /// Authority that sets the creator of the token
+    pub set_creator_authority: Pubkey,
 }
 
 impl GlobalAccount {
-   /// Creates a new global account instance
-   ///
-   /// # Arguments
-   /// * `discriminator` - Unique identifier for the account
-   /// * `initialized` - Whether the account is initialized
-   /// * `authority` - Authority pubkey that can modify settings
-   /// * `fee_recipient` - Account that receives fees
-   /// * `initial_virtual_token_reserves` - Initial virtual token reserves
-   /// * `initial_virtual_sol_reserves` - Initial virtual SOL reserves
-   /// * `initial_real_token_reserves` - Initial actual token reserves
-   /// * `token_total_supply` - Total supply of tokens
-   /// * `fee_basis_points` - Fee in basis points
-   /// * `withdraw_authority` - Authority that can withdraw funds
-   /// * `enable_migrate` - Flag to enable pool migration
-   /// * `pool_migration_fee` - Fee for migrating pools
-   /// * `creator_fee_basis_points` - Fee for creators in base points
-   /// * `fee_recipients` - Array of public keys for fee recipients
-   /// * `set_creator_authority` - Authority that sets the creator of the token
-   #[allow(clippy::too_many_arguments)]
-   pub fn new(
-      discriminator: u64,
-      initialized: bool,
-      authority: Pubkey,
-      fee_recipient: Pubkey,
-      initial_virtual_token_reserves: u64,
-      initial_virtual_sol_reserves: u64,
-      initial_real_token_reserves: u64,
-      token_total_supply: u64,
-      fee_basis_points: u64,
-      withdraw_authority: Pubkey,
-      enable_migrate: bool,
-      pool_migration_fee: u64,
-      creator_fee_basis_points: u64,
-      fee_recipients: [Pubkey; 7],
-      set_creator_authority: Pubkey,
-   ) -> Self {
-      Self {
-         discriminator,
-         initialized,
-         authority,
-         fee_recipient,
-         initial_virtual_token_reserves,
-         initial_virtual_sol_reserves,
-         initial_real_token_reserves,
-         token_total_supply,
-         fee_basis_points,
-         withdraw_authority,
-         enable_migrate,
-         pool_migration_fee,
-         creator_fee_basis_points,
-         fee_recipients,
-         set_creator_authority,
-      }
-   }
+    /// Creates a new global account instance
+    ///
+    /// # Arguments
+    /// * `discriminator` - Unique identifier for the account
+    /// * `initialized` - Whether the account is initialized
+    /// * `authority` - Authority pubkey that can modify settings
+    /// * `fee_recipient` - Account that receives fees
+    /// * `initial_virtual_token_reserves` - Initial virtual token reserves
+    /// * `initial_virtual_sol_reserves` - Initial virtual SOL reserves
+    /// * `initial_real_token_reserves` - Initial actual token reserves
+    /// * `token_total_supply` - Total supply of tokens
+    /// * `fee_basis_points` - Fee in basis points
+    /// * `withdraw_authority` - Authority that can withdraw funds
+    /// * `enable_migrate` - Flag to enable pool migration
+    /// * `pool_migration_fee` - Fee for migrating pools
+    /// * `creator_fee_basis_points` - Fee for creators in base points
+    /// * `fee_recipients` - Array of public keys for fee recipients
+    /// * `set_creator_authority` - Authority that sets the creator of the token
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        discriminator: u64,
+        initialized: bool,
+        authority: Pubkey,
+        fee_recipient: Pubkey,
+        initial_virtual_token_reserves: u64,
+        initial_virtual_sol_reserves: u64,
+        initial_real_token_reserves: u64,
+        token_total_supply: u64,
+        fee_basis_points: u64,
+        withdraw_authority: Pubkey,
+        enable_migrate: bool,
+        pool_migration_fee: u64,
+        creator_fee_basis_points: u64,
+        fee_recipients: [Pubkey; 7],
+        set_creator_authority: Pubkey,
+    ) -> Self {
+        Self {
+            discriminator,
+            initialized,
+            authority,
+            fee_recipient,
+            initial_virtual_token_reserves,
+            initial_virtual_sol_reserves,
+            initial_real_token_reserves,
+            token_total_supply,
+            fee_basis_points,
+            withdraw_authority,
+            enable_migrate,
+            pool_migration_fee,
+            creator_fee_basis_points,
+            fee_recipients,
+            set_creator_authority,
+        }
+    }
 
-   /// Calculates the initial amount of tokens received for a given SOL amount
-   ///
-   /// # Arguments
-   /// * `amount` - Amount of SOL to spend
-   ///
-   /// # Returns
-   /// Amount of tokens that would be received
-   pub fn get_initial_buy_price(&self, amount: u64) -> u64 {
-      if amount == 0 {
-         return 0;
-      }
+    /// Calculates the initial amount of tokens received for a given SOL amount
+    ///
+    /// # Arguments
+    /// * `amount` - Amount of SOL to spend
+    ///
+    /// # Returns
+    /// Amount of tokens that would be received
+    pub fn get_initial_buy_price(&self, amount: u64) -> u64 {
+        if amount == 0 {
+            return 0;
+        }
 
-      let n: u128 = (self.initial_virtual_sol_reserves as u128)
-         * (self.initial_virtual_token_reserves as u128);
-      let i: u128 = (self.initial_virtual_sol_reserves as u128) + (amount as u128);
-      let r: u128 = n / i + 1;
-      let s: u128 = (self.initial_virtual_token_reserves as u128) - r;
+        let n: u128 = (self.initial_virtual_sol_reserves as u128)
+            * (self.initial_virtual_token_reserves as u128);
+        let i: u128 = (self.initial_virtual_sol_reserves as u128) + (amount as u128);
+        let r: u128 = n / i + 1;
+        let s: u128 = (self.initial_virtual_token_reserves as u128) - r;
 
-      if s < (self.initial_real_token_reserves as u128) {
-         s as u64
-      } else {
-         self.initial_real_token_reserves
-      }
-   }
+        if s < (self.initial_real_token_reserves as u128) {
+            s as u64
+        } else {
+            self.initial_real_token_reserves
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-   use super::*;
+    use super::*;
 
-   fn get_global() -> GlobalAccount {
-      GlobalAccount::new(
-         1,
-         true,
-         Pubkey::new_unique(),
-         Pubkey::new_unique(),
-         1000,
-         1000,
-         500,
-         1000,
-         250,
-         Pubkey::new_unique(),
-         true,
-         100,
-         0,
-         [Pubkey::new_unique(); 7],
-         Pubkey::new_unique(),
-      )
-   }
+    fn get_global() -> GlobalAccount {
+        GlobalAccount::new(
+            1,
+            true,
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            1000,
+            1000,
+            500,
+            1000,
+            250,
+            Pubkey::new_unique(),
+            true,
+            100,
+            0,
+            [Pubkey::new_unique(); 7],
+            Pubkey::new_unique(),
+        )
+    }
 
-   fn get_large_global() -> GlobalAccount {
-      GlobalAccount::new(
-         1,
-         true,
-         Pubkey::new_unique(),
-         Pubkey::new_unique(),
-         u64::MAX,
-         u64::MAX,
-         u64::MAX / 2,
-         u64::MAX,
-         250,
-         Pubkey::new_unique(),
-         true,
-         u64::MAX,
-         u64::MAX,
-         [Pubkey::new_unique(); 7],
-         Pubkey::new_unique(),
-      )
-   }
+    fn get_large_global() -> GlobalAccount {
+        GlobalAccount::new(
+            1,
+            true,
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            u64::MAX,
+            u64::MAX,
+            u64::MAX / 2,
+            u64::MAX,
+            250,
+            Pubkey::new_unique(),
+            true,
+            u64::MAX,
+            u64::MAX,
+            [Pubkey::new_unique(); 7],
+            Pubkey::new_unique(),
+        )
+    }
 
-   #[test]
-   fn test_global_account() {
-      let global: GlobalAccount = get_global();
+    #[test]
+    fn test_global_account() {
+        let global: GlobalAccount = get_global();
 
-      // Test initial buy price calculation
-      assert_eq!(global.get_initial_buy_price(0), 0);
+        // Test initial buy price calculation
+        assert_eq!(global.get_initial_buy_price(0), 0);
 
-      let price: u64 = global.get_initial_buy_price(100);
-      assert!(price > 0);
-      assert!(price <= global.initial_real_token_reserves);
-   }
+        let price: u64 = global.get_initial_buy_price(100);
+        assert!(price > 0);
+        assert!(price <= global.initial_real_token_reserves);
+    }
 
-   #[test]
-   fn test_global_account_max_reserves() {
-      let mut global: GlobalAccount = get_global();
-      global.initial_real_token_reserves = 100;
+    #[test]
+    fn test_global_account_max_reserves() {
+        let mut global: GlobalAccount = get_global();
+        global.initial_real_token_reserves = 100;
 
-      // Test that returned amount is capped by real_token_reserves
-      let price: u64 = global.get_initial_buy_price(1000);
-      assert_eq!(price, global.initial_real_token_reserves);
-   }
+        // Test that returned amount is capped by real_token_reserves
+        let price: u64 = global.get_initial_buy_price(1000);
+        assert_eq!(price, global.initial_real_token_reserves);
+    }
 
-   #[test]
-   fn test_global_account_overflow() {
-      let global: GlobalAccount = get_large_global();
+    #[test]
+    fn test_global_account_overflow() {
+        let global: GlobalAccount = get_large_global();
 
-      // Test with maximum possible SOL amount
-      let price: u64 = global.get_initial_buy_price(u64::MAX);
-      assert!(price > 0);
-      assert!(price <= global.initial_real_token_reserves);
+        // Test with maximum possible SOL amount
+        let price: u64 = global.get_initial_buy_price(u64::MAX);
+        assert!(price > 0);
+        assert!(price <= global.initial_real_token_reserves);
 
-      // Test with large but not maximum SOL amount
-      let price: u64 = global.get_initial_buy_price(u64::MAX / 2);
-      assert!(price > 0);
-      assert!(price <= global.initial_real_token_reserves);
-   }
+        // Test with large but not maximum SOL amount
+        let price: u64 = global.get_initial_buy_price(u64::MAX / 2);
+        assert!(price > 0);
+        assert!(price <= global.initial_real_token_reserves);
+    }
 
-   #[test]
-   fn test_global_account_overflow_edge_cases() {
-      let mut global: GlobalAccount = get_large_global();
-      global.initial_virtual_sol_reserves = u64::MAX - 1000;
-      global.initial_virtual_token_reserves = u64::MAX - 1000;
-      global.initial_real_token_reserves = u64::MAX / 4;
+    #[test]
+    fn test_global_account_overflow_edge_cases() {
+        let mut global: GlobalAccount = get_large_global();
+        global.initial_virtual_sol_reserves = u64::MAX - 1000;
+        global.initial_virtual_token_reserves = u64::MAX - 1000;
+        global.initial_real_token_reserves = u64::MAX / 4;
 
-      // Test with amounts near u64::MAX
-      let price: u64 = global.get_initial_buy_price(u64::MAX - 1);
-      assert!(price > 0);
-      assert!(price <= global.initial_real_token_reserves);
+        // Test with amounts near u64::MAX
+        let price: u64 = global.get_initial_buy_price(u64::MAX - 1);
+        assert!(price > 0);
+        assert!(price <= global.initial_real_token_reserves);
 
-      let price: u64 = global.get_initial_buy_price(u64::MAX - 1000);
-      assert!(price > 0);
-      assert!(price <= global.initial_real_token_reserves);
-   }
+        let price: u64 = global.get_initial_buy_price(u64::MAX - 1000);
+        assert!(price > 0);
+        assert!(price <= global.initial_real_token_reserves);
+    }
 }

--- a/src/common/stream.rs
+++ b/src/common/stream.rs
@@ -5,9 +5,9 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use solana_client::{
-    nonblocking::pubsub_client::PubsubClient,
-    rpc_config::{RpcTransactionLogsConfig, RpcTransactionLogsFilter},
-    rpc_response::{Response, RpcLogsResponse},
+   nonblocking::pubsub_client::PubsubClient,
+   rpc_config::{RpcTransactionLogsConfig, RpcTransactionLogsFilter},
+   rpc_response::{Response, RpcLogsResponse},
 };
 use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
 use tokio::sync::mpsc;
@@ -22,14 +22,14 @@ use crate::{constants, error};
 /// metadata, mint address, bonding curve address, and the accounts involved.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize)]
 pub struct CreateEvent {
-    pub name: String,
-    pub symbol: String,
-    pub uri: String,
-    pub mint: Pubkey,
-    pub bonding_curve: Pubkey,
-    pub user: Pubkey,
-    pub creator: Pubkey,
-    pub timestamp: i64,
+   pub name: String,
+   pub symbol: String,
+   pub uri: String,
+   pub mint: Pubkey,
+   pub bonding_curve: Pubkey,
+   pub user: Pubkey,
+   pub creator: Pubkey,
+   pub timestamp: i64,
 }
 
 /// Event emitted when a token is bought or sold
@@ -38,16 +38,22 @@ pub struct CreateEvent {
 /// exchanged, the type of trade (buy/sell), and the updated bonding curve state.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize)]
 pub struct TradeEvent {
-    pub mint: Pubkey,
-    pub sol_amount: u64,
-    pub token_amount: u64,
-    pub is_buy: bool,
-    pub user: Pubkey,
-    pub timestamp: i64,
-    pub virtual_sol_reserves: u64,
-    pub virtual_token_reserves: u64,
-    pub real_sol_reserves: u64,
-    pub real_token_reserves: u64,
+   pub mint: Pubkey,
+   pub sol_amount: u64,
+   pub token_amount: u64,
+   pub is_buy: bool,
+   pub user: Pubkey,
+   pub timestamp: i64,
+   pub virtual_sol_reserves: u64,
+   pub virtual_token_reserves: u64,
+   pub real_sol_reserves: u64,
+   pub real_token_reserves: u64,
+   pub fee_recipient: Pubkey,
+   pub fee_basis_points: u64,
+   pub fee: u64,
+   pub creator: Pubkey,
+   pub creator_fee_basis_points: u64,
+   pub creator_fee: u64,
 }
 
 /// Event emitted when a bonding curve operation completes
@@ -56,10 +62,10 @@ pub struct TradeEvent {
 /// providing information about the involved accounts.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize)]
 pub struct CompleteEvent {
-    pub user: Pubkey,
-    pub mint: Pubkey,
-    pub bonding_curve: Pubkey,
-    pub timestamp: i64,
+   pub user: Pubkey,
+   pub mint: Pubkey,
+   pub bonding_curve: Pubkey,
+   pub timestamp: i64,
 }
 
 /// Event emitted when global parameters are updated
@@ -68,12 +74,12 @@ pub struct CompleteEvent {
 /// including fee settings and initial bonding curve configuration values.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize)]
 pub struct SetParamsEvent {
-    pub fee_recipient: Pubkey,
-    pub initial_virtual_token_reserves: u64,
-    pub initial_virtual_sol_reserves: u64,
-    pub initial_real_token_reserves: u64,
-    pub token_total_supply: u64,
-    pub fee_basis_points: u64,
+   pub fee_recipient: Pubkey,
+   pub initial_virtual_token_reserves: u64,
+   pub initial_virtual_sol_reserves: u64,
+   pub initial_real_token_reserves: u64,
+   pub token_total_supply: u64,
+   pub fee_basis_points: u64,
 }
 
 /// Enum representing all possible event types emitted by the Pump.fun program
@@ -82,10 +88,10 @@ pub struct SetParamsEvent {
 /// emitted by the program. It's used to provide a unified type for event handlers.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum PumpFunEvent {
-    Create(CreateEvent),
-    Trade(TradeEvent),
-    Complete(CompleteEvent),
-    SetParams(SetParamsEvent),
+   Create(CreateEvent),
+   Trade(TradeEvent),
+   Complete(CompleteEvent),
+   SetParams(SetParamsEvent),
 }
 
 /// Represents an active WebSocket subscription to Pump.fun events
@@ -93,21 +99,21 @@ pub enum PumpFunEvent {
 /// This struct manages the lifecycle of an event subscription, automatically
 /// unsubscribing when dropped to ensure proper cleanup of resources.
 pub struct Subscription {
-    pub task: JoinHandle<()>,
-    pub unsubscribe: Box<dyn Fn() + Send>,
+   pub task: JoinHandle<()>,
+   pub unsubscribe: Box<dyn Fn() + Send>,
 }
 
 impl Subscription {
-    pub fn new(task: JoinHandle<()>, unsubscribe: Box<dyn Fn() + Send>) -> Self {
-        Subscription { task, unsubscribe }
-    }
+   pub fn new(task: JoinHandle<()>, unsubscribe: Box<dyn Fn() + Send>) -> Self {
+      Subscription { task, unsubscribe }
+   }
 }
 
 impl Drop for Subscription {
-    fn drop(&mut self) {
-        (self.unsubscribe)();
-        self.task.abort();
-    }
+   fn drop(&mut self) {
+      (self.unsubscribe)();
+      self.task.abort();
+   }
 }
 
 /// Parses base64-encoded program log data into a structured PumpFunEvent
@@ -125,34 +131,34 @@ impl Drop for Subscription {
 ///
 /// Returns a parsed PumpFunEvent if successful, or an error if parsing fails
 pub fn parse_event(signature: &str, data: &str) -> Result<PumpFunEvent, Box<dyn Error>> {
-    // Decode base64
-    let decoded = base64::engine::general_purpose::STANDARD.decode(data)?;
+   // Decode base64
+   let decoded = base64::engine::general_purpose::STANDARD.decode(data)?;
 
-    // Get event type from the first 8 bytes
-    if decoded.len() < 8 {
-        return Err(format!("Data too short to contain discriminator: {}", data).into());
-    }
+   // Get event type from the first 8 bytes
+   if decoded.len() < 8 {
+      return Err(format!("Data too short to contain discriminator: {}", data).into());
+   }
 
-    let discriminator = &decoded[..8];
-    match discriminator {
-        // CreateEvent
-        [27, 114, 169, 77, 222, 235, 99, 118] => Ok(PumpFunEvent::Create(
-            CreateEvent::try_from_slice(&decoded[8..])?,
-        )),
-        // TradeEvent
-        [189, 219, 127, 211, 78, 230, 97, 238] => Ok(PumpFunEvent::Trade(
-            TradeEvent::try_from_slice(&decoded[8..])?,
-        )),
-        // CompleteEvent
-        [95, 114, 97, 156, 212, 46, 152, 8] => Ok(PumpFunEvent::Complete(
-            CompleteEvent::try_from_slice(&decoded[8..])?,
-        )),
-        // SetParamsEvent
-        [223, 195, 159, 246, 62, 48, 143, 131] => Ok(PumpFunEvent::SetParams(
-            SetParamsEvent::try_from_slice(&decoded[8..])?,
-        )),
-        _ => Err(format!("Unknown event: signature={} data={}", signature, data).into()),
-    }
+   let discriminator = &decoded[..8];
+   match discriminator {
+      // CreateEvent
+      [27, 114, 169, 77, 222, 235, 99, 118] => Ok(PumpFunEvent::Create(
+         CreateEvent::try_from_slice(&decoded[8..])?,
+      )),
+      // TradeEvent
+      [189, 219, 127, 211, 78, 230, 97, 238] => Ok(PumpFunEvent::Trade(
+         TradeEvent::try_from_slice(&decoded[8..])?,
+      )),
+      // CompleteEvent
+      [95, 114, 97, 156, 212, 46, 152, 8] => Ok(PumpFunEvent::Complete(
+         CompleteEvent::try_from_slice(&decoded[8..])?,
+      )),
+      // SetParamsEvent
+      [223, 195, 159, 246, 62, 48, 143, 131] => Ok(PumpFunEvent::SetParams(
+         SetParamsEvent::try_from_slice(&decoded[8..])?,
+      )),
+      _ => Err(format!("Unknown event: signature={} data={}", signature, data).into()),
+   }
 }
 
 /// Subscribes to Pump.fun program events emitted on-chain
@@ -220,129 +226,129 @@ pub fn parse_event(signature: &str, data: &str) -> Result<PumpFunEvent, Box<dyn 
 /// }
 /// ```
 pub async fn subscribe<F>(
-    cluster: Cluster,
-    commitment: Option<CommitmentConfig>,
-    callback: F,
+   cluster: Cluster,
+   commitment: Option<CommitmentConfig>,
+   callback: F,
 ) -> Result<Subscription, error::ClientError>
 where
-    F: Fn(String, Option<PumpFunEvent>, Option<Box<dyn Error>>, Response<RpcLogsResponse>)
-        + Send
-        + Sync
-        + 'static,
+   F: Fn(String, Option<PumpFunEvent>, Option<Box<dyn Error>>, Response<RpcLogsResponse>)
+      + Send
+      + Sync
+      + 'static,
 {
-    // Initialize PubsubClient
-    let ws_url = &cluster.rpc.ws;
-    let pubsub_client = PubsubClient::new(ws_url)
-        .await
-        .map_err(error::ClientError::PubsubClientError)?;
+   // Initialize PubsubClient
+   let ws_url = &cluster.rpc.ws;
+   let pubsub_client = PubsubClient::new(ws_url)
+      .await
+      .map_err(error::ClientError::PubsubClientError)?;
 
-    let (tx, _) = mpsc::channel(1);
+   let (tx, _) = mpsc::channel(1);
 
-    let task = tokio::spawn(async move {
-        // Subscribe to logs for the program
-        let (mut stream, _unsubscribe) = pubsub_client
-            .logs_subscribe(
-                RpcTransactionLogsFilter::Mentions(vec![constants::accounts::PUMPFUN.to_string()]),
-                RpcTransactionLogsConfig {
-                    commitment: Some(commitment.unwrap_or(cluster.commitment)),
-                },
-            )
-            .await
-            .unwrap();
+   let task = tokio::spawn(async move {
+      // Subscribe to logs for the program
+      let (mut stream, _unsubscribe) = pubsub_client
+         .logs_subscribe(
+            RpcTransactionLogsFilter::Mentions(vec![constants::accounts::PUMPFUN.to_string()]),
+            RpcTransactionLogsConfig {
+               commitment: Some(commitment.unwrap_or(cluster.commitment)),
+            },
+         )
+         .await
+         .unwrap();
 
-        // Process incoming logs
-        while let Some(log) = stream.next().await {
-            // Get the signature of the transaction
-            let signature = log.value.signature.clone();
-            // Check for logs with "Program data:" prefix
-            for log_line in log.value.logs.clone() {
-                if log_line.starts_with("Program data:") {
-                    // Extract base64-encoded data
-                    let data = log_line.replace("Program data: ", "").trim().to_string();
-                    match parse_event(&signature, &data) {
-                        Ok(event) => callback(signature.clone(), Some(event), None, log.clone()),
-                        Err(err) => callback(signature.clone(), None, Some(err), log.clone()),
-                    }
-                }
+      // Process incoming logs
+      while let Some(log) = stream.next().await {
+         // Get the signature of the transaction
+         let signature = log.value.signature.clone();
+         // Check for logs with "Program data:" prefix
+         for log_line in log.value.logs.clone() {
+            if log_line.starts_with("Program data:") {
+               // Extract base64-encoded data
+               let data = log_line.replace("Program data: ", "").trim().to_string();
+               match parse_event(&signature, &data) {
+                  Ok(event) => callback(signature.clone(), Some(event), None, log.clone()),
+                  Err(err) => callback(signature.clone(), None, Some(err), log.clone()),
+               }
             }
-        }
-    });
+         }
+      }
+   });
 
-    Ok(Subscription::new(
-        task,
-        Box::new(move || {
-            let _ = tx.try_send(());
-        }),
-    ))
+   Ok(Subscription::new(
+      task,
+      Box::new(move || {
+         let _ = tx.try_send(());
+      }),
+   ))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::common::types::PriorityFee;
+   use crate::common::types::PriorityFee;
 
-    use super::*;
-    use std::sync::Arc;
-    use tokio::sync::Mutex;
-    use tokio::time::{timeout, Duration};
+   use super::*;
+   use std::sync::Arc;
+   use tokio::sync::Mutex;
+   use tokio::time::{timeout, Duration};
 
-    #[cfg(not(skip_expensive_tests))]
-    #[tokio::test]
-    async fn test_subscribe() {
-        if std::env::var("SKIP_EXPENSIVE_TESTS").is_ok() {
-            return;
-        }
+   #[cfg(not(skip_expensive_tests))]
+   #[tokio::test]
+   async fn test_subscribe() {
+      if std::env::var("SKIP_EXPENSIVE_TESTS").is_ok() {
+         return;
+      }
 
-        // Define the cluster
-        let cluster = Cluster::mainnet(CommitmentConfig::processed(), PriorityFee::default());
+      // Define the cluster
+      let cluster = Cluster::mainnet(CommitmentConfig::processed(), PriorityFee::default());
 
-        // Shared vector to collect events
-        let events: Arc<Mutex<Vec<PumpFunEvent>>> = Arc::new(Mutex::new(Vec::new()));
+      // Shared vector to collect events
+      let events: Arc<Mutex<Vec<PumpFunEvent>>> = Arc::new(Mutex::new(Vec::new()));
 
-        // Define the callback to store events
-        let callback = {
-            let events = Arc::clone(&events);
-            move |signature: String,
-                  event: Option<PumpFunEvent>,
-                  err: Option<Box<dyn Error>>,
-                  _: Response<RpcLogsResponse>| {
-                if let Some(event) = event {
-                    let events = Arc::clone(&events);
-                    tokio::spawn(async move {
-                        let mut events = events.lock().await;
-                        events.push(event);
-                    });
-                } else if err.is_some() {
-                    eprintln!("Error in subscription: signature={}", signature);
-                }
+      // Define the callback to store events
+      let callback = {
+         let events = Arc::clone(&events);
+         move |signature: String,
+               event: Option<PumpFunEvent>,
+               err: Option<Box<dyn Error>>,
+               _: Response<RpcLogsResponse>| {
+            if let Some(event) = event {
+               let events = Arc::clone(&events);
+               tokio::spawn(async move {
+                  let mut events = events.lock().await;
+                  events.push(event);
+               });
+            } else if err.is_some() {
+               eprintln!("Error in subscription: signature={}", signature);
             }
-        };
+         }
+      };
 
-        // Start the subscription
-        let subscription = subscribe(cluster, None, callback)
-            .await
-            .expect("Failed to start subscription");
+      // Start the subscription
+      let subscription = subscribe(cluster, None, callback)
+         .await
+         .expect("Failed to start subscription");
 
-        // Wait for 30 seconds to collect events
-        let wait_duration = Duration::from_secs(30);
-        timeout(wait_duration, async {
-            loop {
-                tokio::time::sleep(Duration::from_secs(1)).await;
-            }
-        })
-        .await
-        .unwrap_err(); // Expect a timeout error to end the waiting period
+      // Wait for 30 seconds to collect events
+      let wait_duration = Duration::from_secs(30);
+      timeout(wait_duration, async {
+         loop {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+         }
+      })
+      .await
+      .unwrap_err(); // Expect a timeout error to end the waiting period
 
-        // Clean up the subscription
-        drop(subscription);
+      // Clean up the subscription
+      drop(subscription);
 
-        // Verify that at least one event was received
-        let events = events.lock().await;
-        assert!(
-            !events.is_empty(),
-            "No events received within {} seconds",
-            wait_duration.as_secs()
-        );
+      // Verify that at least one event was received
+      let events = events.lock().await;
+      assert!(
+         !events.is_empty(),
+         "No events received within {} seconds",
+         wait_duration.as_secs()
+      );
 
-        println!("Received {} events", events.len());
-    }
+      println!("Received {} events", events.len());
+   }
 }

--- a/src/common/stream.rs
+++ b/src/common/stream.rs
@@ -30,6 +30,10 @@ pub struct CreateEvent {
     pub user: Pubkey,
     pub creator: Pubkey,
     pub timestamp: i64,
+    pub virtual_sol_reserves: u64,
+    pub virtual_token_reserves: u64,
+    pub real_sol_reserves: u64,
+    pub real_token_reserves: u64,
 }
 
 /// Event emitted when a token is bought or sold
@@ -143,19 +147,23 @@ pub fn parse_event(signature: &str, data: &str) -> Result<PumpFunEvent, Box<dyn 
     match discriminator {
         // CreateEvent
         [27, 114, 169, 77, 222, 235, 99, 118] => Ok(PumpFunEvent::Create(
-            CreateEvent::try_from_slice(&decoded[8..])?,
+            CreateEvent::try_from_slice(&decoded[8..])
+                .map_err(|e| format!("Failed to decode CreateEvent: {}", e))?,
         )),
         // TradeEvent
         [189, 219, 127, 211, 78, 230, 97, 238] => Ok(PumpFunEvent::Trade(
-            TradeEvent::try_from_slice(&decoded[8..])?,
+            TradeEvent::try_from_slice(&decoded[8..])
+                .map_err(|e| format!("Failed to decode TradeEvent: {}", e))?,
         )),
         // CompleteEvent
         [95, 114, 97, 156, 212, 46, 152, 8] => Ok(PumpFunEvent::Complete(
-            CompleteEvent::try_from_slice(&decoded[8..])?,
+            CompleteEvent::try_from_slice(&decoded[8..])
+                .map_err(|e| format!("Failed to decode CompleteEvent: {}", e))?,
         )),
         // SetParamsEvent
         [223, 195, 159, 246, 62, 48, 143, 131] => Ok(PumpFunEvent::SetParams(
-            SetParamsEvent::try_from_slice(&decoded[8..])?,
+            SetParamsEvent::try_from_slice(&decoded[8..])
+                .map_err(|e| format!("Failed to decode SetParamsEvent: {}", e))?,
         )),
         _ => Err(format!("Unknown event: signature={} data={}", signature, data).into()),
     }

--- a/src/common/stream.rs
+++ b/src/common/stream.rs
@@ -182,7 +182,7 @@ pub fn parse_event(signature: &str, data: &str) -> Result<PumpFunEvent, Box<dyn 
 ///
 /// * `cluster` - Solana cluster configuration containing RPC endpoints
 /// * `commitment` - Optional commitment level for the subscription. If None, uses the
-///                  default from the cluster configuration
+///   default from the cluster configuration
 /// * `callback` - A function that will be called for each event with the following parameters:
 ///   * `signature`: The transaction signature as a String
 ///   * `event`: The parsed PumpFunEvent if successful, or None if parsing failed

--- a/src/common/stream.rs
+++ b/src/common/stream.rs
@@ -5,9 +5,9 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use solana_client::{
-   nonblocking::pubsub_client::PubsubClient,
-   rpc_config::{RpcTransactionLogsConfig, RpcTransactionLogsFilter},
-   rpc_response::{Response, RpcLogsResponse},
+    nonblocking::pubsub_client::PubsubClient,
+    rpc_config::{RpcTransactionLogsConfig, RpcTransactionLogsFilter},
+    rpc_response::{Response, RpcLogsResponse},
 };
 use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
 use tokio::sync::mpsc;
@@ -22,14 +22,14 @@ use crate::{constants, error};
 /// metadata, mint address, bonding curve address, and the accounts involved.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize)]
 pub struct CreateEvent {
-   pub name: String,
-   pub symbol: String,
-   pub uri: String,
-   pub mint: Pubkey,
-   pub bonding_curve: Pubkey,
-   pub user: Pubkey,
-   pub creator: Pubkey,
-   pub timestamp: i64,
+    pub name: String,
+    pub symbol: String,
+    pub uri: String,
+    pub mint: Pubkey,
+    pub bonding_curve: Pubkey,
+    pub user: Pubkey,
+    pub creator: Pubkey,
+    pub timestamp: i64,
 }
 
 /// Event emitted when a token is bought or sold
@@ -38,22 +38,22 @@ pub struct CreateEvent {
 /// exchanged, the type of trade (buy/sell), and the updated bonding curve state.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize)]
 pub struct TradeEvent {
-   pub mint: Pubkey,
-   pub sol_amount: u64,
-   pub token_amount: u64,
-   pub is_buy: bool,
-   pub user: Pubkey,
-   pub timestamp: i64,
-   pub virtual_sol_reserves: u64,
-   pub virtual_token_reserves: u64,
-   pub real_sol_reserves: u64,
-   pub real_token_reserves: u64,
-   pub fee_recipient: Pubkey,
-   pub fee_basis_points: u64,
-   pub fee: u64,
-   pub creator: Pubkey,
-   pub creator_fee_basis_points: u64,
-   pub creator_fee: u64,
+    pub mint: Pubkey,
+    pub sol_amount: u64,
+    pub token_amount: u64,
+    pub is_buy: bool,
+    pub user: Pubkey,
+    pub timestamp: i64,
+    pub virtual_sol_reserves: u64,
+    pub virtual_token_reserves: u64,
+    pub real_sol_reserves: u64,
+    pub real_token_reserves: u64,
+    pub fee_recipient: Pubkey,
+    pub fee_basis_points: u64,
+    pub fee: u64,
+    pub creator: Pubkey,
+    pub creator_fee_basis_points: u64,
+    pub creator_fee: u64,
 }
 
 /// Event emitted when a bonding curve operation completes
@@ -62,10 +62,10 @@ pub struct TradeEvent {
 /// providing information about the involved accounts.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize)]
 pub struct CompleteEvent {
-   pub user: Pubkey,
-   pub mint: Pubkey,
-   pub bonding_curve: Pubkey,
-   pub timestamp: i64,
+    pub user: Pubkey,
+    pub mint: Pubkey,
+    pub bonding_curve: Pubkey,
+    pub timestamp: i64,
 }
 
 /// Event emitted when global parameters are updated
@@ -74,12 +74,12 @@ pub struct CompleteEvent {
 /// including fee settings and initial bonding curve configuration values.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize)]
 pub struct SetParamsEvent {
-   pub fee_recipient: Pubkey,
-   pub initial_virtual_token_reserves: u64,
-   pub initial_virtual_sol_reserves: u64,
-   pub initial_real_token_reserves: u64,
-   pub token_total_supply: u64,
-   pub fee_basis_points: u64,
+    pub fee_recipient: Pubkey,
+    pub initial_virtual_token_reserves: u64,
+    pub initial_virtual_sol_reserves: u64,
+    pub initial_real_token_reserves: u64,
+    pub token_total_supply: u64,
+    pub fee_basis_points: u64,
 }
 
 /// Enum representing all possible event types emitted by the Pump.fun program
@@ -88,10 +88,10 @@ pub struct SetParamsEvent {
 /// emitted by the program. It's used to provide a unified type for event handlers.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum PumpFunEvent {
-   Create(CreateEvent),
-   Trade(TradeEvent),
-   Complete(CompleteEvent),
-   SetParams(SetParamsEvent),
+    Create(CreateEvent),
+    Trade(TradeEvent),
+    Complete(CompleteEvent),
+    SetParams(SetParamsEvent),
 }
 
 /// Represents an active WebSocket subscription to Pump.fun events
@@ -99,21 +99,21 @@ pub enum PumpFunEvent {
 /// This struct manages the lifecycle of an event subscription, automatically
 /// unsubscribing when dropped to ensure proper cleanup of resources.
 pub struct Subscription {
-   pub task: JoinHandle<()>,
-   pub unsubscribe: Box<dyn Fn() + Send>,
+    pub task: JoinHandle<()>,
+    pub unsubscribe: Box<dyn Fn() + Send>,
 }
 
 impl Subscription {
-   pub fn new(task: JoinHandle<()>, unsubscribe: Box<dyn Fn() + Send>) -> Self {
-      Subscription { task, unsubscribe }
-   }
+    pub fn new(task: JoinHandle<()>, unsubscribe: Box<dyn Fn() + Send>) -> Self {
+        Subscription { task, unsubscribe }
+    }
 }
 
 impl Drop for Subscription {
-   fn drop(&mut self) {
-      (self.unsubscribe)();
-      self.task.abort();
-   }
+    fn drop(&mut self) {
+        (self.unsubscribe)();
+        self.task.abort();
+    }
 }
 
 /// Parses base64-encoded program log data into a structured PumpFunEvent
@@ -131,34 +131,34 @@ impl Drop for Subscription {
 ///
 /// Returns a parsed PumpFunEvent if successful, or an error if parsing fails
 pub fn parse_event(signature: &str, data: &str) -> Result<PumpFunEvent, Box<dyn Error>> {
-   // Decode base64
-   let decoded = base64::engine::general_purpose::STANDARD.decode(data)?;
+    // Decode base64
+    let decoded = base64::engine::general_purpose::STANDARD.decode(data)?;
 
-   // Get event type from the first 8 bytes
-   if decoded.len() < 8 {
-      return Err(format!("Data too short to contain discriminator: {}", data).into());
-   }
+    // Get event type from the first 8 bytes
+    if decoded.len() < 8 {
+        return Err(format!("Data too short to contain discriminator: {}", data).into());
+    }
 
-   let discriminator = &decoded[..8];
-   match discriminator {
-      // CreateEvent
-      [27, 114, 169, 77, 222, 235, 99, 118] => Ok(PumpFunEvent::Create(
-         CreateEvent::try_from_slice(&decoded[8..])?,
-      )),
-      // TradeEvent
-      [189, 219, 127, 211, 78, 230, 97, 238] => Ok(PumpFunEvent::Trade(
-         TradeEvent::try_from_slice(&decoded[8..])?,
-      )),
-      // CompleteEvent
-      [95, 114, 97, 156, 212, 46, 152, 8] => Ok(PumpFunEvent::Complete(
-         CompleteEvent::try_from_slice(&decoded[8..])?,
-      )),
-      // SetParamsEvent
-      [223, 195, 159, 246, 62, 48, 143, 131] => Ok(PumpFunEvent::SetParams(
-         SetParamsEvent::try_from_slice(&decoded[8..])?,
-      )),
-      _ => Err(format!("Unknown event: signature={} data={}", signature, data).into()),
-   }
+    let discriminator = &decoded[..8];
+    match discriminator {
+        // CreateEvent
+        [27, 114, 169, 77, 222, 235, 99, 118] => Ok(PumpFunEvent::Create(
+            CreateEvent::try_from_slice(&decoded[8..])?,
+        )),
+        // TradeEvent
+        [189, 219, 127, 211, 78, 230, 97, 238] => Ok(PumpFunEvent::Trade(
+            TradeEvent::try_from_slice(&decoded[8..])?,
+        )),
+        // CompleteEvent
+        [95, 114, 97, 156, 212, 46, 152, 8] => Ok(PumpFunEvent::Complete(
+            CompleteEvent::try_from_slice(&decoded[8..])?,
+        )),
+        // SetParamsEvent
+        [223, 195, 159, 246, 62, 48, 143, 131] => Ok(PumpFunEvent::SetParams(
+            SetParamsEvent::try_from_slice(&decoded[8..])?,
+        )),
+        _ => Err(format!("Unknown event: signature={} data={}", signature, data).into()),
+    }
 }
 
 /// Subscribes to Pump.fun program events emitted on-chain
@@ -226,129 +226,129 @@ pub fn parse_event(signature: &str, data: &str) -> Result<PumpFunEvent, Box<dyn 
 /// }
 /// ```
 pub async fn subscribe<F>(
-   cluster: Cluster,
-   commitment: Option<CommitmentConfig>,
-   callback: F,
+    cluster: Cluster,
+    commitment: Option<CommitmentConfig>,
+    callback: F,
 ) -> Result<Subscription, error::ClientError>
 where
-   F: Fn(String, Option<PumpFunEvent>, Option<Box<dyn Error>>, Response<RpcLogsResponse>)
-      + Send
-      + Sync
-      + 'static,
+    F: Fn(String, Option<PumpFunEvent>, Option<Box<dyn Error>>, Response<RpcLogsResponse>)
+        + Send
+        + Sync
+        + 'static,
 {
-   // Initialize PubsubClient
-   let ws_url = &cluster.rpc.ws;
-   let pubsub_client = PubsubClient::new(ws_url)
-      .await
-      .map_err(error::ClientError::PubsubClientError)?;
+    // Initialize PubsubClient
+    let ws_url = &cluster.rpc.ws;
+    let pubsub_client = PubsubClient::new(ws_url)
+        .await
+        .map_err(error::ClientError::PubsubClientError)?;
 
-   let (tx, _) = mpsc::channel(1);
+    let (tx, _) = mpsc::channel(1);
 
-   let task = tokio::spawn(async move {
-      // Subscribe to logs for the program
-      let (mut stream, _unsubscribe) = pubsub_client
-         .logs_subscribe(
-            RpcTransactionLogsFilter::Mentions(vec![constants::accounts::PUMPFUN.to_string()]),
-            RpcTransactionLogsConfig {
-               commitment: Some(commitment.unwrap_or(cluster.commitment)),
-            },
-         )
-         .await
-         .unwrap();
+    let task = tokio::spawn(async move {
+        // Subscribe to logs for the program
+        let (mut stream, _unsubscribe) = pubsub_client
+            .logs_subscribe(
+                RpcTransactionLogsFilter::Mentions(vec![constants::accounts::PUMPFUN.to_string()]),
+                RpcTransactionLogsConfig {
+                    commitment: Some(commitment.unwrap_or(cluster.commitment)),
+                },
+            )
+            .await
+            .unwrap();
 
-      // Process incoming logs
-      while let Some(log) = stream.next().await {
-         // Get the signature of the transaction
-         let signature = log.value.signature.clone();
-         // Check for logs with "Program data:" prefix
-         for log_line in log.value.logs.clone() {
-            if log_line.starts_with("Program data:") {
-               // Extract base64-encoded data
-               let data = log_line.replace("Program data: ", "").trim().to_string();
-               match parse_event(&signature, &data) {
-                  Ok(event) => callback(signature.clone(), Some(event), None, log.clone()),
-                  Err(err) => callback(signature.clone(), None, Some(err), log.clone()),
-               }
+        // Process incoming logs
+        while let Some(log) = stream.next().await {
+            // Get the signature of the transaction
+            let signature = log.value.signature.clone();
+            // Check for logs with "Program data:" prefix
+            for log_line in log.value.logs.clone() {
+                if log_line.starts_with("Program data:") {
+                    // Extract base64-encoded data
+                    let data = log_line.replace("Program data: ", "").trim().to_string();
+                    match parse_event(&signature, &data) {
+                        Ok(event) => callback(signature.clone(), Some(event), None, log.clone()),
+                        Err(err) => callback(signature.clone(), None, Some(err), log.clone()),
+                    }
+                }
             }
-         }
-      }
-   });
+        }
+    });
 
-   Ok(Subscription::new(
-      task,
-      Box::new(move || {
-         let _ = tx.try_send(());
-      }),
-   ))
+    Ok(Subscription::new(
+        task,
+        Box::new(move || {
+            let _ = tx.try_send(());
+        }),
+    ))
 }
 
 #[cfg(test)]
 mod tests {
-   use crate::common::types::PriorityFee;
+    use crate::common::types::PriorityFee;
 
-   use super::*;
-   use std::sync::Arc;
-   use tokio::sync::Mutex;
-   use tokio::time::{timeout, Duration};
+    use super::*;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+    use tokio::time::{timeout, Duration};
 
-   #[cfg(not(skip_expensive_tests))]
-   #[tokio::test]
-   async fn test_subscribe() {
-      if std::env::var("SKIP_EXPENSIVE_TESTS").is_ok() {
-         return;
-      }
+    #[cfg(not(skip_expensive_tests))]
+    #[tokio::test]
+    async fn test_subscribe() {
+        if std::env::var("SKIP_EXPENSIVE_TESTS").is_ok() {
+            return;
+        }
 
-      // Define the cluster
-      let cluster = Cluster::mainnet(CommitmentConfig::processed(), PriorityFee::default());
+        // Define the cluster
+        let cluster = Cluster::mainnet(CommitmentConfig::processed(), PriorityFee::default());
 
-      // Shared vector to collect events
-      let events: Arc<Mutex<Vec<PumpFunEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        // Shared vector to collect events
+        let events: Arc<Mutex<Vec<PumpFunEvent>>> = Arc::new(Mutex::new(Vec::new()));
 
-      // Define the callback to store events
-      let callback = {
-         let events = Arc::clone(&events);
-         move |signature: String,
-               event: Option<PumpFunEvent>,
-               err: Option<Box<dyn Error>>,
-               _: Response<RpcLogsResponse>| {
-            if let Some(event) = event {
-               let events = Arc::clone(&events);
-               tokio::spawn(async move {
-                  let mut events = events.lock().await;
-                  events.push(event);
-               });
-            } else if err.is_some() {
-               eprintln!("Error in subscription: signature={}", signature);
+        // Define the callback to store events
+        let callback = {
+            let events = Arc::clone(&events);
+            move |signature: String,
+                  event: Option<PumpFunEvent>,
+                  err: Option<Box<dyn Error>>,
+                  _: Response<RpcLogsResponse>| {
+                if let Some(event) = event {
+                    let events = Arc::clone(&events);
+                    tokio::spawn(async move {
+                        let mut events = events.lock().await;
+                        events.push(event);
+                    });
+                } else if err.is_some() {
+                    eprintln!("Error in subscription: signature={}", signature);
+                }
             }
-         }
-      };
+        };
 
-      // Start the subscription
-      let subscription = subscribe(cluster, None, callback)
-         .await
-         .expect("Failed to start subscription");
+        // Start the subscription
+        let subscription = subscribe(cluster, None, callback)
+            .await
+            .expect("Failed to start subscription");
 
-      // Wait for 30 seconds to collect events
-      let wait_duration = Duration::from_secs(30);
-      timeout(wait_duration, async {
-         loop {
-            tokio::time::sleep(Duration::from_secs(1)).await;
-         }
-      })
-      .await
-      .unwrap_err(); // Expect a timeout error to end the waiting period
+        // Wait for 30 seconds to collect events
+        let wait_duration = Duration::from_secs(30);
+        timeout(wait_duration, async {
+            loop {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        })
+        .await
+        .unwrap_err(); // Expect a timeout error to end the waiting period
 
-      // Clean up the subscription
-      drop(subscription);
+        // Clean up the subscription
+        drop(subscription);
 
-      // Verify that at least one event was received
-      let events = events.lock().await;
-      assert!(
-         !events.is_empty(),
-         "No events received within {} seconds",
-         wait_duration.as_secs()
-      );
+        // Verify that at least one event was received
+        let events = events.lock().await;
+        assert!(
+            !events.is_empty(),
+            "No events received within {} seconds",
+            wait_duration.as_secs()
+        );
 
-      println!("Received {} events", events.len());
-   }
+        println!("Received {} events", events.len());
+    }
 }

--- a/src/constants/mod.rs
+++ b/src/constants/mod.rs
@@ -12,45 +12,45 @@
 
 /// Constants used as seeds for deriving PDAs (Program Derived Addresses)
 pub mod seeds {
-   /// Seed for the global state PDA
-   pub const GLOBAL_SEED: &[u8] = b"global";
+    /// Seed for the global state PDA
+    pub const GLOBAL_SEED: &[u8] = b"global";
 
-   /// Seed for the mint authority PDA
-   pub const MINT_AUTHORITY_SEED: &[u8] = b"mint-authority";
+    /// Seed for the mint authority PDA
+    pub const MINT_AUTHORITY_SEED: &[u8] = b"mint-authority";
 
-   /// Seed for bonding curve PDAs
-   pub const BONDING_CURVE_SEED: &[u8] = b"bonding-curve";
+    /// Seed for bonding curve PDAs
+    pub const BONDING_CURVE_SEED: &[u8] = b"bonding-curve";
 
-   /// Seed for metadata PDAs
-   pub const METADATA_SEED: &[u8] = b"metadata";
+    /// Seed for metadata PDAs
+    pub const METADATA_SEED: &[u8] = b"metadata";
 
-   /// Seed for creator vault PDA
-   pub const CREATOR_VAULT_SEED: &[u8] = b"creator-vault";
+    /// Seed for creator vault PDA
+    pub const CREATOR_VAULT_SEED: &[u8] = b"creator-vault";
 }
 
 /// Constants related to program accounts and authorities
 pub mod accounts {
-   use solana_sdk::{pubkey, pubkey::Pubkey};
+    use solana_sdk::{pubkey, pubkey::Pubkey};
 
-   /// Public key for the Pump.fun program
-   pub const PUMPFUN: Pubkey = pubkey!("6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P");
+    /// Public key for the Pump.fun program
+    pub const PUMPFUN: Pubkey = pubkey!("6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P");
 
-   /// Public key for the MPL Token Metadata program
-   pub const MPL_TOKEN_METADATA: Pubkey = pubkey!("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");
+    /// Public key for the MPL Token Metadata program
+    pub const MPL_TOKEN_METADATA: Pubkey = pubkey!("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");
 
-   /// Authority for program events
-   pub const EVENT_AUTHORITY: Pubkey = pubkey!("Ce6TQqeHC9p8KetsN6JsjHK7UTZk7nasjjnr7XxXp9F1");
+    /// Authority for program events
+    pub const EVENT_AUTHORITY: Pubkey = pubkey!("Ce6TQqeHC9p8KetsN6JsjHK7UTZk7nasjjnr7XxXp9F1");
 
-   /// System Program ID
-   pub const SYSTEM_PROGRAM: Pubkey = pubkey!("11111111111111111111111111111111");
+    /// System Program ID
+    pub const SYSTEM_PROGRAM: Pubkey = pubkey!("11111111111111111111111111111111");
 
-   /// Token Program ID
-   pub const TOKEN_PROGRAM: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+    /// Token Program ID
+    pub const TOKEN_PROGRAM: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
-   /// Associated Token Program ID
-   pub const ASSOCIATED_TOKEN_PROGRAM: Pubkey =
-      pubkey!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+    /// Associated Token Program ID
+    pub const ASSOCIATED_TOKEN_PROGRAM: Pubkey =
+        pubkey!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
 
-   /// Rent Sysvar ID
-   pub const RENT: Pubkey = pubkey!("SysvarRent111111111111111111111111111111111");
+    /// Rent Sysvar ID
+    pub const RENT: Pubkey = pubkey!("SysvarRent111111111111111111111111111111111");
 }

--- a/src/constants/mod.rs
+++ b/src/constants/mod.rs
@@ -12,42 +12,45 @@
 
 /// Constants used as seeds for deriving PDAs (Program Derived Addresses)
 pub mod seeds {
-    /// Seed for the global state PDA
-    pub const GLOBAL_SEED: &[u8] = b"global";
+   /// Seed for the global state PDA
+   pub const GLOBAL_SEED: &[u8] = b"global";
 
-    /// Seed for the mint authority PDA
-    pub const MINT_AUTHORITY_SEED: &[u8] = b"mint-authority";
+   /// Seed for the mint authority PDA
+   pub const MINT_AUTHORITY_SEED: &[u8] = b"mint-authority";
 
-    /// Seed for bonding curve PDAs
-    pub const BONDING_CURVE_SEED: &[u8] = b"bonding-curve";
+   /// Seed for bonding curve PDAs
+   pub const BONDING_CURVE_SEED: &[u8] = b"bonding-curve";
 
-    /// Seed for metadata PDAs
-    pub const METADATA_SEED: &[u8] = b"metadata";
+   /// Seed for metadata PDAs
+   pub const METADATA_SEED: &[u8] = b"metadata";
+
+   /// Seed for creator vault PDA
+   pub const CREATOR_VAULT_SEED: &[u8] = b"creator-vault";
 }
 
 /// Constants related to program accounts and authorities
 pub mod accounts {
-    use solana_sdk::{pubkey, pubkey::Pubkey};
+   use solana_sdk::{pubkey, pubkey::Pubkey};
 
-    /// Public key for the Pump.fun program
-    pub const PUMPFUN: Pubkey = pubkey!("6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P");
+   /// Public key for the Pump.fun program
+   pub const PUMPFUN: Pubkey = pubkey!("6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P");
 
-    /// Public key for the MPL Token Metadata program
-    pub const MPL_TOKEN_METADATA: Pubkey = pubkey!("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");
+   /// Public key for the MPL Token Metadata program
+   pub const MPL_TOKEN_METADATA: Pubkey = pubkey!("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s");
 
-    /// Authority for program events
-    pub const EVENT_AUTHORITY: Pubkey = pubkey!("Ce6TQqeHC9p8KetsN6JsjHK7UTZk7nasjjnr7XxXp9F1");
+   /// Authority for program events
+   pub const EVENT_AUTHORITY: Pubkey = pubkey!("Ce6TQqeHC9p8KetsN6JsjHK7UTZk7nasjjnr7XxXp9F1");
 
-    /// System Program ID
-    pub const SYSTEM_PROGRAM: Pubkey = pubkey!("11111111111111111111111111111111");
+   /// System Program ID
+   pub const SYSTEM_PROGRAM: Pubkey = pubkey!("11111111111111111111111111111111");
 
-    /// Token Program ID
-    pub const TOKEN_PROGRAM: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+   /// Token Program ID
+   pub const TOKEN_PROGRAM: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
-    /// Associated Token Program ID
-    pub const ASSOCIATED_TOKEN_PROGRAM: Pubkey =
-        pubkey!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+   /// Associated Token Program ID
+   pub const ASSOCIATED_TOKEN_PROGRAM: Pubkey =
+      pubkey!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
 
-    /// Rent Sysvar ID
-    pub const RENT: Pubkey = pubkey!("SysvarRent111111111111111111111111111111111");
+   /// Rent Sysvar ID
+   pub const RENT: Pubkey = pubkey!("SysvarRent111111111111111111111111111111111");
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -16,6 +16,7 @@
 //! - `OtherError`: An error occurred that is not covered by the other error types.
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum ClientError {
     /// Bonding curve account was not found
     BondingCurveNotFound,

--- a/src/instructions/buy.rs
+++ b/src/instructions/buy.rs
@@ -6,10 +6,10 @@
 use crate::{constants, PumpFun};
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_sdk::{
-   instruction::{AccountMeta, Instruction},
-   pubkey::Pubkey,
-   signature::Keypair,
-   signer::Signer,
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
 };
 use spl_associated_token_account::get_associated_token_address;
 
@@ -21,25 +21,25 @@ use spl_associated_token_account::get_associated_token_address;
 /// * `max_sol_cost` - Maximum acceptable SOL cost for the purchase (slippage protection)
 #[derive(BorshSerialize, BorshDeserialize, Clone)]
 pub struct Buy {
-   pub amount: u64,
-   pub max_sol_cost: u64,
+    pub amount: u64,
+    pub max_sol_cost: u64,
 }
 
 impl Buy {
-   /// Instruction discriminator used to identify this instruction
-   pub const DISCRIMINATOR: [u8; 8] = [102, 6, 61, 18, 1, 218, 235, 234];
+    /// Instruction discriminator used to identify this instruction
+    pub const DISCRIMINATOR: [u8; 8] = [102, 6, 61, 18, 1, 218, 235, 234];
 
-   /// Serializes the instruction data with the appropriate discriminator
-   ///
-   /// # Returns
-   ///
-   /// Byte vector containing the serialized instruction data
-   pub fn data(&self) -> Vec<u8> {
-      let mut data = Vec::with_capacity(256);
-      data.extend_from_slice(&Self::DISCRIMINATOR);
-      self.serialize(&mut data).unwrap();
-      data
-   }
+    /// Serializes the instruction data with the appropriate discriminator
+    ///
+    /// # Returns
+    ///
+    /// Byte vector containing the serialized instruction data
+    pub fn data(&self) -> Vec<u8> {
+        let mut data = Vec::with_capacity(256);
+        data.extend_from_slice(&Self::DISCRIMINATOR);
+        self.serialize(&mut data).unwrap();
+        data
+    }
 }
 
 /// Creates an instruction to buy tokens from a bonding curve
@@ -77,30 +77,30 @@ impl Buy {
 /// 11. Event authority (readonly)
 /// 12. Pump.fun program ID (readonly)
 pub fn buy(
-   payer: &Keypair,
-   mint: &Pubkey,
-   fee_recipient: &Pubkey,
-   creator: &Pubkey,
-   args: Buy,
+    payer: &Keypair,
+    mint: &Pubkey,
+    fee_recipient: &Pubkey,
+    creator: &Pubkey,
+    args: Buy,
 ) -> Instruction {
-   let bonding_curve: Pubkey = PumpFun::get_bonding_curve_pda(mint).unwrap();
-   let creator_vault: Pubkey = PumpFun::get_creator_vault_pda(creator).unwrap();
-   Instruction::new_with_bytes(
-      constants::accounts::PUMPFUN,
-      &args.data(),
-      vec![
-         AccountMeta::new_readonly(PumpFun::get_global_pda(), false),
-         AccountMeta::new(*fee_recipient, false),
-         AccountMeta::new_readonly(*mint, false),
-         AccountMeta::new(bonding_curve, false),
-         AccountMeta::new(get_associated_token_address(&bonding_curve, mint), false),
-         AccountMeta::new(get_associated_token_address(&payer.pubkey(), mint), false),
-         AccountMeta::new(payer.pubkey(), true),
-         AccountMeta::new_readonly(constants::accounts::SYSTEM_PROGRAM, false),
-         AccountMeta::new_readonly(constants::accounts::TOKEN_PROGRAM, false),
-         AccountMeta::new(creator_vault, false),
-         AccountMeta::new_readonly(constants::accounts::EVENT_AUTHORITY, false),
-         AccountMeta::new_readonly(constants::accounts::PUMPFUN, false),
-      ],
-   )
+    let bonding_curve: Pubkey = PumpFun::get_bonding_curve_pda(mint).unwrap();
+    let creator_vault: Pubkey = PumpFun::get_creator_vault_pda(creator).unwrap();
+    Instruction::new_with_bytes(
+        constants::accounts::PUMPFUN,
+        &args.data(),
+        vec![
+            AccountMeta::new_readonly(PumpFun::get_global_pda(), false),
+            AccountMeta::new(*fee_recipient, false),
+            AccountMeta::new_readonly(*mint, false),
+            AccountMeta::new(bonding_curve, false),
+            AccountMeta::new(get_associated_token_address(&bonding_curve, mint), false),
+            AccountMeta::new(get_associated_token_address(&payer.pubkey(), mint), false),
+            AccountMeta::new(payer.pubkey(), true),
+            AccountMeta::new_readonly(constants::accounts::SYSTEM_PROGRAM, false),
+            AccountMeta::new_readonly(constants::accounts::TOKEN_PROGRAM, false),
+            AccountMeta::new(creator_vault, false),
+            AccountMeta::new_readonly(constants::accounts::EVENT_AUTHORITY, false),
+            AccountMeta::new_readonly(constants::accounts::PUMPFUN, false),
+        ],
+    )
 }

--- a/src/instructions/buy.rs
+++ b/src/instructions/buy.rs
@@ -6,10 +6,10 @@
 use crate::{constants, PumpFun};
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_sdk::{
-    instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
-    signature::Keypair,
-    signer::Signer,
+   instruction::{AccountMeta, Instruction},
+   pubkey::Pubkey,
+   signature::Keypair,
+   signer::Signer,
 };
 use spl_associated_token_account::get_associated_token_address;
 
@@ -21,25 +21,25 @@ use spl_associated_token_account::get_associated_token_address;
 /// * `max_sol_cost` - Maximum acceptable SOL cost for the purchase (slippage protection)
 #[derive(BorshSerialize, BorshDeserialize, Clone)]
 pub struct Buy {
-    pub amount: u64,
-    pub max_sol_cost: u64,
+   pub amount: u64,
+   pub max_sol_cost: u64,
 }
 
 impl Buy {
-    /// Instruction discriminator used to identify this instruction
-    pub const DISCRIMINATOR: [u8; 8] = [102, 6, 61, 18, 1, 218, 235, 234];
+   /// Instruction discriminator used to identify this instruction
+   pub const DISCRIMINATOR: [u8; 8] = [102, 6, 61, 18, 1, 218, 235, 234];
 
-    /// Serializes the instruction data with the appropriate discriminator
-    ///
-    /// # Returns
-    ///
-    /// Byte vector containing the serialized instruction data
-    pub fn data(&self) -> Vec<u8> {
-        let mut data = Vec::with_capacity(256);
-        data.extend_from_slice(&Self::DISCRIMINATOR);
-        self.serialize(&mut data).unwrap();
-        data
-    }
+   /// Serializes the instruction data with the appropriate discriminator
+   ///
+   /// # Returns
+   ///
+   /// Byte vector containing the serialized instruction data
+   pub fn data(&self) -> Vec<u8> {
+      let mut data = Vec::with_capacity(256);
+      data.extend_from_slice(&Self::DISCRIMINATOR);
+      self.serialize(&mut data).unwrap();
+      data
+   }
 }
 
 /// Creates an instruction to buy tokens from a bonding curve
@@ -54,6 +54,7 @@ impl Buy {
 /// * `payer` - Keypair that will provide the SOL to buy tokens
 /// * `mint` - Public key of the token mint to buy
 /// * `fee_recipient` - Public key of the account that will receive the transaction fee
+/// * `creator` - Public key of the token's creator
 /// * `args` - Buy instruction data containing the token amount and maximum acceptable SOL price
 ///
 /// # Returns
@@ -72,27 +73,34 @@ impl Buy {
 /// 7. Payer account (signer, writable)
 /// 8. System program (readonly)
 /// 9. Token program (readonly)
-/// 10. Rent sysvar (readonly)
+/// 10. Creator vault (writable)
 /// 11. Event authority (readonly)
 /// 12. Pump.fun program ID (readonly)
-pub fn buy(payer: &Keypair, mint: &Pubkey, fee_recipient: &Pubkey, args: Buy) -> Instruction {
-    let bonding_curve: Pubkey = PumpFun::get_bonding_curve_pda(mint).unwrap();
-    Instruction::new_with_bytes(
-        constants::accounts::PUMPFUN,
-        &args.data(),
-        vec![
-            AccountMeta::new_readonly(PumpFun::get_global_pda(), false),
-            AccountMeta::new(*fee_recipient, false),
-            AccountMeta::new_readonly(*mint, false),
-            AccountMeta::new(bonding_curve, false),
-            AccountMeta::new(get_associated_token_address(&bonding_curve, mint), false),
-            AccountMeta::new(get_associated_token_address(&payer.pubkey(), mint), false),
-            AccountMeta::new(payer.pubkey(), true),
-            AccountMeta::new_readonly(constants::accounts::SYSTEM_PROGRAM, false),
-            AccountMeta::new_readonly(constants::accounts::TOKEN_PROGRAM, false),
-            AccountMeta::new_readonly(constants::accounts::RENT, false),
-            AccountMeta::new_readonly(constants::accounts::EVENT_AUTHORITY, false),
-            AccountMeta::new_readonly(constants::accounts::PUMPFUN, false),
-        ],
-    )
+pub fn buy(
+   payer: &Keypair,
+   mint: &Pubkey,
+   fee_recipient: &Pubkey,
+   creator: &Pubkey,
+   args: Buy,
+) -> Instruction {
+   let bonding_curve: Pubkey = PumpFun::get_bonding_curve_pda(mint).unwrap();
+   let creator_vault: Pubkey = PumpFun::get_creator_vault_pda(creator).unwrap();
+   Instruction::new_with_bytes(
+      constants::accounts::PUMPFUN,
+      &args.data(),
+      vec![
+         AccountMeta::new_readonly(PumpFun::get_global_pda(), false),
+         AccountMeta::new(*fee_recipient, false),
+         AccountMeta::new_readonly(*mint, false),
+         AccountMeta::new(bonding_curve, false),
+         AccountMeta::new(get_associated_token_address(&bonding_curve, mint), false),
+         AccountMeta::new(get_associated_token_address(&payer.pubkey(), mint), false),
+         AccountMeta::new(payer.pubkey(), true),
+         AccountMeta::new_readonly(constants::accounts::SYSTEM_PROGRAM, false),
+         AccountMeta::new_readonly(constants::accounts::TOKEN_PROGRAM, false),
+         AccountMeta::new(creator_vault, false),
+         AccountMeta::new_readonly(constants::accounts::EVENT_AUTHORITY, false),
+         AccountMeta::new_readonly(constants::accounts::PUMPFUN, false),
+      ],
+   )
 }

--- a/src/instructions/sell.rs
+++ b/src/instructions/sell.rs
@@ -6,10 +6,10 @@
 use crate::{constants, PumpFun};
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_sdk::{
-    instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
-    signature::Keypair,
-    signer::Signer,
+   instruction::{AccountMeta, Instruction},
+   pubkey::Pubkey,
+   signature::Keypair,
+   signer::Signer,
 };
 use spl_associated_token_account::get_associated_token_address;
 
@@ -21,25 +21,25 @@ use spl_associated_token_account::get_associated_token_address;
 /// * `min_sol_output` - Minimum acceptable SOL received for the sale (slippage protection)
 #[derive(BorshSerialize, BorshDeserialize, Clone)]
 pub struct Sell {
-    pub amount: u64,
-    pub min_sol_output: u64,
+   pub amount: u64,
+   pub min_sol_output: u64,
 }
 
 impl Sell {
-    /// Instruction discriminator used to identify this instruction
-    pub const DISCRIMINATOR: [u8; 8] = [51, 230, 133, 164, 1, 127, 131, 173];
+   /// Instruction discriminator used to identify this instruction
+   pub const DISCRIMINATOR: [u8; 8] = [51, 230, 133, 164, 1, 127, 131, 173];
 
-    /// Serializes the instruction data with the appropriate discriminator
-    ///
-    /// # Returns
-    ///
-    /// Byte vector containing the serialized instruction data
-    pub fn data(&self) -> Vec<u8> {
-        let mut data = Vec::with_capacity(256);
-        data.extend_from_slice(&Self::DISCRIMINATOR);
-        self.serialize(&mut data).unwrap();
-        data
-    }
+   /// Serializes the instruction data with the appropriate discriminator
+   ///
+   /// # Returns
+   ///
+   /// Byte vector containing the serialized instruction data
+   pub fn data(&self) -> Vec<u8> {
+      let mut data = Vec::with_capacity(256);
+      data.extend_from_slice(&Self::DISCRIMINATOR);
+      self.serialize(&mut data).unwrap();
+      data
+   }
 }
 
 /// Creates an instruction to sell tokens back to a bonding curve
@@ -54,6 +54,7 @@ impl Sell {
 /// * `payer` - Keypair that owns the tokens to sell
 /// * `mint` - Public key of the token mint to sell
 /// * `fee_recipient` - Public key of the account that will receive the transaction fee
+/// * `creator` - Public key of the token's creator
 /// * `args` - Sell instruction data containing token amount and minimum acceptable SOL output
 ///
 /// # Returns
@@ -71,28 +72,35 @@ impl Sell {
 /// 6. Seller's token account (writable)
 /// 7. Payer account (signer, writable)
 /// 8. System program (readonly)
-/// 9. Associated token program (readonly)
+/// 9. Creator vault (writable)
 /// 10. Token program (readonly)
 /// 11. Event authority (readonly)
 /// 12. Pump.fun program ID (readonly)
-pub fn sell(payer: &Keypair, mint: &Pubkey, fee_recipient: &Pubkey, args: Sell) -> Instruction {
-    let bonding_curve: Pubkey = PumpFun::get_bonding_curve_pda(mint).unwrap();
-    Instruction::new_with_bytes(
-        constants::accounts::PUMPFUN,
-        &args.data(),
-        vec![
-            AccountMeta::new_readonly(PumpFun::get_global_pda(), false),
-            AccountMeta::new(*fee_recipient, false),
-            AccountMeta::new_readonly(*mint, false),
-            AccountMeta::new(bonding_curve, false),
-            AccountMeta::new(get_associated_token_address(&bonding_curve, mint), false),
-            AccountMeta::new(get_associated_token_address(&payer.pubkey(), mint), false),
-            AccountMeta::new(payer.pubkey(), true),
-            AccountMeta::new_readonly(constants::accounts::SYSTEM_PROGRAM, false),
-            AccountMeta::new_readonly(constants::accounts::ASSOCIATED_TOKEN_PROGRAM, false),
-            AccountMeta::new_readonly(constants::accounts::TOKEN_PROGRAM, false),
-            AccountMeta::new_readonly(constants::accounts::EVENT_AUTHORITY, false),
-            AccountMeta::new_readonly(constants::accounts::PUMPFUN, false),
-        ],
-    )
+pub fn sell(
+   payer: &Keypair,
+   mint: &Pubkey,
+   fee_recipient: &Pubkey,
+   creator: &Pubkey,
+   args: Sell,
+) -> Instruction {
+   let bonding_curve: Pubkey = PumpFun::get_bonding_curve_pda(mint).unwrap();
+   let creator_vault: Pubkey = PumpFun::get_creator_vault_pda(creator).unwrap();
+   Instruction::new_with_bytes(
+      constants::accounts::PUMPFUN,
+      &args.data(),
+      vec![
+         AccountMeta::new_readonly(PumpFun::get_global_pda(), false),
+         AccountMeta::new(*fee_recipient, false),
+         AccountMeta::new_readonly(*mint, false),
+         AccountMeta::new(bonding_curve, false),
+         AccountMeta::new(get_associated_token_address(&bonding_curve, mint), false),
+         AccountMeta::new(get_associated_token_address(&payer.pubkey(), mint), false),
+         AccountMeta::new(payer.pubkey(), true),
+         AccountMeta::new_readonly(constants::accounts::SYSTEM_PROGRAM, false),
+         AccountMeta::new(creator_vault, false),
+         AccountMeta::new_readonly(constants::accounts::TOKEN_PROGRAM, false),
+         AccountMeta::new_readonly(constants::accounts::EVENT_AUTHORITY, false),
+         AccountMeta::new_readonly(constants::accounts::PUMPFUN, false),
+      ],
+   )
 }

--- a/src/instructions/sell.rs
+++ b/src/instructions/sell.rs
@@ -6,10 +6,10 @@
 use crate::{constants, PumpFun};
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_sdk::{
-   instruction::{AccountMeta, Instruction},
-   pubkey::Pubkey,
-   signature::Keypair,
-   signer::Signer,
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
 };
 use spl_associated_token_account::get_associated_token_address;
 
@@ -21,25 +21,25 @@ use spl_associated_token_account::get_associated_token_address;
 /// * `min_sol_output` - Minimum acceptable SOL received for the sale (slippage protection)
 #[derive(BorshSerialize, BorshDeserialize, Clone)]
 pub struct Sell {
-   pub amount: u64,
-   pub min_sol_output: u64,
+    pub amount: u64,
+    pub min_sol_output: u64,
 }
 
 impl Sell {
-   /// Instruction discriminator used to identify this instruction
-   pub const DISCRIMINATOR: [u8; 8] = [51, 230, 133, 164, 1, 127, 131, 173];
+    /// Instruction discriminator used to identify this instruction
+    pub const DISCRIMINATOR: [u8; 8] = [51, 230, 133, 164, 1, 127, 131, 173];
 
-   /// Serializes the instruction data with the appropriate discriminator
-   ///
-   /// # Returns
-   ///
-   /// Byte vector containing the serialized instruction data
-   pub fn data(&self) -> Vec<u8> {
-      let mut data = Vec::with_capacity(256);
-      data.extend_from_slice(&Self::DISCRIMINATOR);
-      self.serialize(&mut data).unwrap();
-      data
-   }
+    /// Serializes the instruction data with the appropriate discriminator
+    ///
+    /// # Returns
+    ///
+    /// Byte vector containing the serialized instruction data
+    pub fn data(&self) -> Vec<u8> {
+        let mut data = Vec::with_capacity(256);
+        data.extend_from_slice(&Self::DISCRIMINATOR);
+        self.serialize(&mut data).unwrap();
+        data
+    }
 }
 
 /// Creates an instruction to sell tokens back to a bonding curve
@@ -77,30 +77,30 @@ impl Sell {
 /// 11. Event authority (readonly)
 /// 12. Pump.fun program ID (readonly)
 pub fn sell(
-   payer: &Keypair,
-   mint: &Pubkey,
-   fee_recipient: &Pubkey,
-   creator: &Pubkey,
-   args: Sell,
+    payer: &Keypair,
+    mint: &Pubkey,
+    fee_recipient: &Pubkey,
+    creator: &Pubkey,
+    args: Sell,
 ) -> Instruction {
-   let bonding_curve: Pubkey = PumpFun::get_bonding_curve_pda(mint).unwrap();
-   let creator_vault: Pubkey = PumpFun::get_creator_vault_pda(creator).unwrap();
-   Instruction::new_with_bytes(
-      constants::accounts::PUMPFUN,
-      &args.data(),
-      vec![
-         AccountMeta::new_readonly(PumpFun::get_global_pda(), false),
-         AccountMeta::new(*fee_recipient, false),
-         AccountMeta::new_readonly(*mint, false),
-         AccountMeta::new(bonding_curve, false),
-         AccountMeta::new(get_associated_token_address(&bonding_curve, mint), false),
-         AccountMeta::new(get_associated_token_address(&payer.pubkey(), mint), false),
-         AccountMeta::new(payer.pubkey(), true),
-         AccountMeta::new_readonly(constants::accounts::SYSTEM_PROGRAM, false),
-         AccountMeta::new(creator_vault, false),
-         AccountMeta::new_readonly(constants::accounts::TOKEN_PROGRAM, false),
-         AccountMeta::new_readonly(constants::accounts::EVENT_AUTHORITY, false),
-         AccountMeta::new_readonly(constants::accounts::PUMPFUN, false),
-      ],
-   )
+    let bonding_curve: Pubkey = PumpFun::get_bonding_curve_pda(mint).unwrap();
+    let creator_vault: Pubkey = PumpFun::get_creator_vault_pda(creator).unwrap();
+    Instruction::new_with_bytes(
+        constants::accounts::PUMPFUN,
+        &args.data(),
+        vec![
+            AccountMeta::new_readonly(PumpFun::get_global_pda(), false),
+            AccountMeta::new(*fee_recipient, false),
+            AccountMeta::new_readonly(*mint, false),
+            AccountMeta::new(bonding_curve, false),
+            AccountMeta::new(get_associated_token_address(&bonding_curve, mint), false),
+            AccountMeta::new(get_associated_token_address(&payer.pubkey(), mint), false),
+            AccountMeta::new(payer.pubkey(), true),
+            AccountMeta::new_readonly(constants::accounts::SYSTEM_PROGRAM, false),
+            AccountMeta::new(creator_vault, false),
+            AccountMeta::new_readonly(constants::accounts::TOKEN_PROGRAM, false),
+            AccountMeta::new_readonly(constants::accounts::EVENT_AUTHORITY, false),
+            AccountMeta::new_readonly(constants::accounts::PUMPFUN, false),
+        ],
+    )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,11 @@ pub mod utils;
 use common::types::{Cluster, PriorityFee};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{
-   compute_budget::ComputeBudgetInstruction,
-   instruction::Instruction,
-   pubkey::Pubkey,
-   signature::{Keypair, Signature},
-   signer::Signer,
+    compute_budget::ComputeBudgetInstruction,
+    instruction::Instruction,
+    pubkey::Pubkey,
+    signature::{Keypair, Signature},
+    signer::Signer,
 };
 use spl_associated_token_account::get_associated_token_address;
 #[cfg(feature = "create-ata")]
@@ -45,1145 +45,1147 @@ use utils::transaction::get_transaction;
 /// let client = PumpFun::new(payer, cluster);
 /// ```
 pub struct PumpFun {
-   /// Keypair used to sign transactions
-   pub payer: Arc<Keypair>,
-   /// RPC client for Solana network requests
-   pub rpc: Arc<RpcClient>,
-   /// Cluster configuration
-   pub cluster: Cluster,
+    /// Keypair used to sign transactions
+    pub payer: Arc<Keypair>,
+    /// RPC client for Solana network requests
+    pub rpc: Arc<RpcClient>,
+    /// Cluster configuration
+    pub cluster: Cluster,
 }
 
 impl PumpFun {
-   /// Creates a new PumpFun client instance
-   ///
-   /// Initializes a new client for interacting with the Pump.fun program on Solana.
-   /// This client manages connection to the Solana network and provides methods for
-   /// creating, buying, and selling tokens.
-   ///
-   /// # Arguments
-   ///
-   /// * `payer` - Keypair used to sign and pay for transactions
-   /// * `cluster` - Solana cluster configuration including RPC endpoints and transaction parameters
-   ///
-   /// # Returns
-   ///
-   /// Returns a new PumpFun client instance configured with the provided parameters
-   ///
-   /// # Examples
-   ///
-   /// ```no_run
-   /// use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
-   /// use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
-   /// use std::sync::Arc;
-   ///
-   /// let payer = Arc::new(Keypair::new());
-   /// let commitment = CommitmentConfig::confirmed();
-   /// let priority_fee = PriorityFee::default();
-   /// let cluster = Cluster::devnet(commitment, priority_fee);
-   /// let client = PumpFun::new(payer, cluster);
-   /// ```
-   pub fn new(payer: Arc<Keypair>, cluster: Cluster) -> Self {
-      // Create Solana RPC Client with HTTP endpoint
-      let rpc = Arc::new(RpcClient::new_with_commitment(
-         cluster.rpc.http.clone(),
-         cluster.commitment,
-      ));
+    /// Creates a new PumpFun client instance
+    ///
+    /// Initializes a new client for interacting with the Pump.fun program on Solana.
+    /// This client manages connection to the Solana network and provides methods for
+    /// creating, buying, and selling tokens.
+    ///
+    /// # Arguments
+    ///
+    /// * `payer` - Keypair used to sign and pay for transactions
+    /// * `cluster` - Solana cluster configuration including RPC endpoints and transaction parameters
+    ///
+    /// # Returns
+    ///
+    /// Returns a new PumpFun client instance configured with the provided parameters
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
+    /// use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
+    /// use std::sync::Arc;
+    ///
+    /// let payer = Arc::new(Keypair::new());
+    /// let commitment = CommitmentConfig::confirmed();
+    /// let priority_fee = PriorityFee::default();
+    /// let cluster = Cluster::devnet(commitment, priority_fee);
+    /// let client = PumpFun::new(payer, cluster);
+    /// ```
+    pub fn new(payer: Arc<Keypair>, cluster: Cluster) -> Self {
+        // Create Solana RPC Client with HTTP endpoint
+        let rpc = Arc::new(RpcClient::new_with_commitment(
+            cluster.rpc.http.clone(),
+            cluster.commitment,
+        ));
 
-      // Return configured PumpFun client
-      Self {
-         payer,
-         rpc,
-         cluster,
-      }
-   }
+        // Return configured PumpFun client
+        Self {
+            payer,
+            rpc,
+            cluster,
+        }
+    }
 
-   /// Creates a new token with metadata by uploading metadata to IPFS and initializing on-chain accounts
-   ///
-   /// This method handles the complete process of creating a new token on Pump.fun:
-   /// 1. Uploads token metadata and image to IPFS
-   /// 2. Creates a new SPL token with the provided mint keypair
-   /// 3. Initializes the bonding curve that determines token pricing
-   /// 4. Sets up metadata using the Metaplex standard
-   ///
-   /// # Arguments
-   ///
-   /// * `mint` - Keypair for the new token mint account that will be created
-   /// * `metadata` - Token metadata including name, symbol, description and image file
-   /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
-   ///                    default from the cluster configuration
-   ///
-   /// # Returns
-   ///
-   /// Returns the transaction signature if successful, or a ClientError if the operation fails
-   ///
-   /// # Errors
-   ///
-   /// Returns an error if:
-   /// - Metadata upload to IPFS fails
-   /// - Transaction creation fails
-   /// - Transaction execution on Solana fails
-   ///
-   /// # Examples
-   ///
-   /// ```no_run
-   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}, utils::CreateTokenMetadata};
-   /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
-   /// # use std::sync::Arc;
-   /// #
-   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-   /// # let payer = Arc::new(Keypair::new());
-   /// # let commitment = CommitmentConfig::confirmed();
-   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-   /// # let client = PumpFun::new(payer, cluster);
-   /// let mint = Keypair::new();
-   /// let metadata = CreateTokenMetadata {
-   ///     name: "My Token".to_string(),
-   ///     symbol: "MYTKN".to_string(),
-   ///     description: "A test token created with Pump.fun".to_string(),
-   ///     file: "path/to/image.png".to_string(),
-   ///     twitter: None,
-   ///     telegram: None,
-   ///     website: Some("https://example.com".to_string()),
-   /// };
-   ///
-   /// let signature = client.create(mint, metadata, None).await?;
-   /// println!("Token created! Signature: {}", signature);
-   /// # Ok(())
-   /// # }
-   /// ```
-   pub async fn create(
-      &self,
-      mint: Keypair,
-      metadata: utils::CreateTokenMetadata,
-      priority_fee: Option<PriorityFee>,
-   ) -> Result<Signature, error::ClientError> {
-      // First upload metadata and image to IPFS
-      let ipfs: utils::TokenMetadataResponse = utils::create_token_metadata(metadata)
-         .await
-         .map_err(error::ClientError::UploadMetadataError)?;
+    /// Creates a new token with metadata by uploading metadata to IPFS and initializing on-chain accounts
+    ///
+    /// This method handles the complete process of creating a new token on Pump.fun:
+    /// 1. Uploads token metadata and image to IPFS
+    /// 2. Creates a new SPL token with the provided mint keypair
+    /// 3. Initializes the bonding curve that determines token pricing
+    /// 4. Sets up metadata using the Metaplex standard
+    ///
+    /// # Arguments
+    ///
+    /// * `mint` - Keypair for the new token mint account that will be created
+    /// * `metadata` - Token metadata including name, symbol, description and image file
+    /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
+    ///                    default from the cluster configuration
+    ///
+    /// # Returns
+    ///
+    /// Returns the transaction signature if successful, or a ClientError if the operation fails
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Metadata upload to IPFS fails
+    /// - Transaction creation fails
+    /// - Transaction execution on Solana fails
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}, utils::CreateTokenMetadata};
+    /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
+    /// # use std::sync::Arc;
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let payer = Arc::new(Keypair::new());
+    /// # let commitment = CommitmentConfig::confirmed();
+    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+    /// # let client = PumpFun::new(payer, cluster);
+    /// let mint = Keypair::new();
+    /// let metadata = CreateTokenMetadata {
+    ///     name: "My Token".to_string(),
+    ///     symbol: "MYTKN".to_string(),
+    ///     description: "A test token created with Pump.fun".to_string(),
+    ///     file: "path/to/image.png".to_string(),
+    ///     twitter: None,
+    ///     telegram: None,
+    ///     website: Some("https://example.com".to_string()),
+    /// };
+    ///
+    /// let signature = client.create(mint, metadata, None).await?;
+    /// println!("Token created! Signature: {}", signature);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create(
+        &self,
+        mint: Keypair,
+        metadata: utils::CreateTokenMetadata,
+        priority_fee: Option<PriorityFee>,
+    ) -> Result<Signature, error::ClientError> {
+        // First upload metadata and image to IPFS
+        let ipfs: utils::TokenMetadataResponse = utils::create_token_metadata(metadata)
+            .await
+            .map_err(error::ClientError::UploadMetadataError)?;
 
-      // Add priority fee if provided or default to cluster priority fee
-      let priority_fee = priority_fee.unwrap_or(self.cluster.priority_fee);
-      let mut instructions = Self::get_priority_fee_instructions(&priority_fee);
+        // Add priority fee if provided or default to cluster priority fee
+        let priority_fee = priority_fee.unwrap_or(self.cluster.priority_fee);
+        let mut instructions = Self::get_priority_fee_instructions(&priority_fee);
 
-      // Add create token instruction
-      let create_ix = self.get_create_instruction(&mint, ipfs);
-      instructions.push(create_ix);
+        // Add create token instruction
+        let create_ix = self.get_create_instruction(&mint, ipfs);
+        instructions.push(create_ix);
 
-      // Create and sign transaction
-      let transaction = get_transaction(
-         self.rpc.clone(),
-         self.payer.clone(),
-         &instructions,
-         Some(&[&mint]),
-         #[cfg(feature = "versioned-tx")]
-         None,
-      )
-      .await?;
+        // Create and sign transaction
+        let transaction = get_transaction(
+            self.rpc.clone(),
+            self.payer.clone(),
+            &instructions,
+            Some(&[&mint]),
+            #[cfg(feature = "versioned-tx")]
+            None,
+        )
+        .await?;
 
-      // Send and confirm transaction
-      let signature = self
-         .rpc
-         .send_and_confirm_transaction(&transaction)
-         .await
-         .map_err(error::ClientError::SolanaClientError)?;
+        // Send and confirm transaction
+        let signature = self
+            .rpc
+            .send_and_confirm_transaction(&transaction)
+            .await
+            .map_err(error::ClientError::SolanaClientError)?;
 
-      Ok(signature)
-   }
+        Ok(signature)
+    }
 
-   /// Creates a new token and immediately buys an initial amount in a single atomic transaction
-   ///
-   /// This method combines token creation and an initial purchase into a single atomic transaction.
-   /// This is often preferred for new token launches as it:
-   /// 1. Creates the token and its bonding curve
-   /// 2. Makes an initial purchase to establish liquidity
-   /// 3. Guarantees that the creator becomes the first holder
-   ///
-   /// The entire operation is executed as a single transaction, ensuring atomicity.
-   ///
-   /// # Arguments
-   ///
-   /// * `mint` - Keypair for the new token mint account that will be created
-   /// * `metadata` - Token metadata including name, symbol, description and image file
-   /// * `amount_sol` - Amount of SOL to spend on the initial buy, in lamports (1 SOL = 1,000,000,000 lamports)
-   /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
-   ///                             If None, defaults to 500 (5%)
-   /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
-   ///                    default from the cluster configuration
-   ///
-   /// # Returns
-   ///
-   /// Returns the transaction signature if successful, or a ClientError if the operation fails
-   ///
-   /// # Errors
-   ///
-   /// Returns an error if:
-   /// - Metadata upload to IPFS fails
-   /// - Account retrieval fails
-   /// - Transaction creation fails
-   /// - Transaction execution on Solana fails
-   ///
-   /// # Examples
-   ///
-   /// ```no_run
-   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}, utils::CreateTokenMetadata};
-   /// # use solana_sdk::{commitment_config::CommitmentConfig, native_token::sol_to_lamports, signature::Keypair};
-   /// # use std::sync::Arc;
-   /// #
-   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-   /// # let payer = Arc::new(Keypair::new());
-   /// # let commitment = CommitmentConfig::confirmed();
-   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-   /// # let client = PumpFun::new(payer, cluster);
-   /// let mint = Keypair::new();
-   /// let metadata = CreateTokenMetadata {
-   ///     name: "My Token".to_string(),
-   ///     symbol: "MYTKN".to_string(),
-   ///     description: "A test token created with Pump.fun".to_string(),
-   ///     file: "path/to/image.png".to_string(),
-   ///     twitter: None,
-   ///     telegram: None,
-   ///     website: Some("https://example.com".to_string()),
-   /// };
-   ///
-   /// // Create token and buy 0.1 SOL worth with 5% slippage tolerance
-   /// let amount_sol = sol_to_lamports(0.1f64); // 0.1 SOL in lamports
-   /// let slippage_bps = Some(500); // 5%
-   ///
-   /// let signature = client.create_and_buy(mint, metadata, amount_sol, slippage_bps, None).await?;
-   /// println!("Token created and bought! Signature: {}", signature);
-   /// # Ok(())
-   /// # }
-   /// ```
-   pub async fn create_and_buy(
-      &self,
-      mint: Keypair,
-      metadata: utils::CreateTokenMetadata,
-      amount_sol: u64,
-      slippage_basis_points: Option<u64>,
-      priority_fee: Option<PriorityFee>,
-   ) -> Result<Signature, error::ClientError> {
-      // Upload metadata to IPFS first
-      let ipfs: utils::TokenMetadataResponse = utils::create_token_metadata(metadata)
-         .await
-         .map_err(error::ClientError::UploadMetadataError)?;
+    /// Creates a new token and immediately buys an initial amount in a single atomic transaction
+    ///
+    /// This method combines token creation and an initial purchase into a single atomic transaction.
+    /// This is often preferred for new token launches as it:
+    /// 1. Creates the token and its bonding curve
+    /// 2. Makes an initial purchase to establish liquidity
+    /// 3. Guarantees that the creator becomes the first holder
+    ///
+    /// The entire operation is executed as a single transaction, ensuring atomicity.
+    ///
+    /// # Arguments
+    ///
+    /// * `mint` - Keypair for the new token mint account that will be created
+    /// * `metadata` - Token metadata including name, symbol, description and image file
+    /// * `amount_sol` - Amount of SOL to spend on the initial buy, in lamports (1 SOL = 1,000,000,000 lamports)
+    /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
+    ///                             If None, defaults to 500 (5%)
+    /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
+    ///                    default from the cluster configuration
+    ///
+    /// # Returns
+    ///
+    /// Returns the transaction signature if successful, or a ClientError if the operation fails
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Metadata upload to IPFS fails
+    /// - Account retrieval fails
+    /// - Transaction creation fails
+    /// - Transaction execution on Solana fails
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}, utils::CreateTokenMetadata};
+    /// # use solana_sdk::{commitment_config::CommitmentConfig, native_token::sol_to_lamports, signature::Keypair};
+    /// # use std::sync::Arc;
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let payer = Arc::new(Keypair::new());
+    /// # let commitment = CommitmentConfig::confirmed();
+    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+    /// # let client = PumpFun::new(payer, cluster);
+    /// let mint = Keypair::new();
+    /// let metadata = CreateTokenMetadata {
+    ///     name: "My Token".to_string(),
+    ///     symbol: "MYTKN".to_string(),
+    ///     description: "A test token created with Pump.fun".to_string(),
+    ///     file: "path/to/image.png".to_string(),
+    ///     twitter: None,
+    ///     telegram: None,
+    ///     website: Some("https://example.com".to_string()),
+    /// };
+    ///
+    /// // Create token and buy 0.1 SOL worth with 5% slippage tolerance
+    /// let amount_sol = sol_to_lamports(0.1f64); // 0.1 SOL in lamports
+    /// let slippage_bps = Some(500); // 5%
+    ///
+    /// let signature = client.create_and_buy(mint, metadata, amount_sol, slippage_bps, None).await?;
+    /// println!("Token created and bought! Signature: {}", signature);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create_and_buy(
+        &self,
+        mint: Keypair,
+        metadata: utils::CreateTokenMetadata,
+        amount_sol: u64,
+        slippage_basis_points: Option<u64>,
+        priority_fee: Option<PriorityFee>,
+    ) -> Result<Signature, error::ClientError> {
+        // Upload metadata to IPFS first
+        let ipfs: utils::TokenMetadataResponse = utils::create_token_metadata(metadata)
+            .await
+            .map_err(error::ClientError::UploadMetadataError)?;
 
-      // Add priority fee if provided or default to cluster priority fee
-      let priority_fee = priority_fee.unwrap_or(self.cluster.priority_fee);
-      let mut instructions = Self::get_priority_fee_instructions(&priority_fee);
+        // Add priority fee if provided or default to cluster priority fee
+        let priority_fee = priority_fee.unwrap_or(self.cluster.priority_fee);
+        let mut instructions = Self::get_priority_fee_instructions(&priority_fee);
 
-      // Add create token instruction
-      let create_ix = self.get_create_instruction(&mint, ipfs);
-      instructions.push(create_ix);
+        // Add create token instruction
+        let create_ix = self.get_create_instruction(&mint, ipfs);
+        instructions.push(create_ix);
 
-      // Add buy instruction
-      let buy_ix = self
-         .get_buy_instructions(mint.pubkey(), amount_sol, slippage_basis_points)
-         .await?;
-      instructions.extend(buy_ix);
+        // Add buy instruction
+        let buy_ix = self
+            .get_buy_instructions(mint.pubkey(), amount_sol, slippage_basis_points)
+            .await?;
+        instructions.extend(buy_ix);
 
-      // Create and sign transaction
-      let transaction = get_transaction(
-         self.rpc.clone(),
-         self.payer.clone(),
-         &instructions,
-         Some(&[&mint]),
-         #[cfg(feature = "versioned-tx")]
-         None,
-      )
-      .await?;
+        // Create and sign transaction
+        let transaction = get_transaction(
+            self.rpc.clone(),
+            self.payer.clone(),
+            &instructions,
+            Some(&[&mint]),
+            #[cfg(feature = "versioned-tx")]
+            None,
+        )
+        .await?;
 
-      // Send and confirm transaction
-      let signature = self
-         .rpc
-         .send_and_confirm_transaction(&transaction)
-         .await
-         .map_err(error::ClientError::SolanaClientError)?;
+        // Send and confirm transaction
+        let signature = self
+            .rpc
+            .send_and_confirm_transaction(&transaction)
+            .await
+            .map_err(error::ClientError::SolanaClientError)?;
 
-      Ok(signature)
-   }
+        Ok(signature)
+    }
 
-   /// Buys tokens from a bonding curve by spending SOL
-   ///
-   /// This method purchases tokens from a bonding curve by providing SOL. The amount of tokens
-   /// received is determined by the bonding curve formula for the specific token. As more tokens
-   /// are purchased, the price increases according to the curve function.
-   ///
-   /// The method:
-   /// 1. Calculates how many tokens will be received for the given SOL amount
-   /// 2. Creates an associated token account for the buyer if needed
-   /// 3. Executes the buy transaction with slippage protection
-   ///
-   /// A portion of the SOL is taken as a fee according to the global configuration.
-   ///
-   /// # Arguments
-   ///
-   /// * `mint` - Public key of the token mint to buy
-   /// * `amount_sol` - Amount of SOL to spend, in lamports (1 SOL = 1,000,000,000 lamports)
-   /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
-   ///                             If None, defaults to 500 (5%)
-   /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
-   ///                    default from the cluster configuration
-   ///
-   /// # Returns
-   ///
-   /// Returns the transaction signature if successful, or a ClientError if the operation fails
-   ///
-   /// # Errors
-   ///
-   /// Returns an error if:
-   /// - The bonding curve account cannot be found
-   /// - The buy price calculation fails
-   /// - Transaction creation fails
-   /// - Transaction execution on Solana fails
-   ///
-   /// # Examples
-   ///
-   /// ```no_run
-   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
-   /// # use solana_sdk::{commitment_config::CommitmentConfig, native_token::sol_to_lamports, pubkey, signature::Keypair};
-   /// # use std::sync::Arc;
-   /// #
-   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-   /// # let payer = Arc::new(Keypair::new());
-   /// # let commitment = CommitmentConfig::confirmed();
-   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-   /// # let client = PumpFun::new(payer, cluster);
-   /// let token_mint = pubkey!("SoMeTokenM1ntAddr3ssXXXXXXXXXXXXXXXXXXXXXXX");
-   ///
-   /// // Buy 0.01 SOL worth of tokens with 3% max slippage
-   /// let amount_sol = sol_to_lamports(0.01f64); // 0.01 SOL in lamports
-   /// let slippage_bps = Some(300); // 3%
-   ///
-   /// let signature = client.buy(token_mint, amount_sol, slippage_bps, None).await?;
-   /// println!("Tokens purchased! Signature: {}", signature);
-   /// # Ok(())
-   /// # }
-   /// ```
-   pub async fn buy(
-      &self,
-      mint: Pubkey,
-      amount_sol: u64,
-      slippage_basis_points: Option<u64>,
-      priority_fee: Option<PriorityFee>,
-   ) -> Result<Signature, error::ClientError> {
-      // Add priority fee if provided or default to cluster priority fee
-      let priority_fee = priority_fee.unwrap_or(self.cluster.priority_fee);
-      let mut instructions = Self::get_priority_fee_instructions(&priority_fee);
+    /// Buys tokens from a bonding curve by spending SOL
+    ///
+    /// This method purchases tokens from a bonding curve by providing SOL. The amount of tokens
+    /// received is determined by the bonding curve formula for the specific token. As more tokens
+    /// are purchased, the price increases according to the curve function.
+    ///
+    /// The method:
+    /// 1. Calculates how many tokens will be received for the given SOL amount
+    /// 2. Creates an associated token account for the buyer if needed
+    /// 3. Executes the buy transaction with slippage protection
+    ///
+    /// A portion of the SOL is taken as a fee according to the global configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `mint` - Public key of the token mint to buy
+    /// * `amount_sol` - Amount of SOL to spend, in lamports (1 SOL = 1,000,000,000 lamports)
+    /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
+    ///                             If None, defaults to 500 (5%)
+    /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
+    ///                    default from the cluster configuration
+    ///
+    /// # Returns
+    ///
+    /// Returns the transaction signature if successful, or a ClientError if the operation fails
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The bonding curve account cannot be found
+    /// - The buy price calculation fails
+    /// - Transaction creation fails
+    /// - Transaction execution on Solana fails
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
+    /// # use solana_sdk::{commitment_config::CommitmentConfig, native_token::sol_to_lamports, pubkey, signature::Keypair};
+    /// # use std::sync::Arc;
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let payer = Arc::new(Keypair::new());
+    /// # let commitment = CommitmentConfig::confirmed();
+    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+    /// # let client = PumpFun::new(payer, cluster);
+    /// let token_mint = pubkey!("SoMeTokenM1ntAddr3ssXXXXXXXXXXXXXXXXXXXXXXX");
+    ///
+    /// // Buy 0.01 SOL worth of tokens with 3% max slippage
+    /// let amount_sol = sol_to_lamports(0.01f64); // 0.01 SOL in lamports
+    /// let slippage_bps = Some(300); // 3%
+    ///
+    /// let signature = client.buy(token_mint, amount_sol, slippage_bps, None).await?;
+    /// println!("Tokens purchased! Signature: {}", signature);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn buy(
+        &self,
+        mint: Pubkey,
+        amount_sol: u64,
+        slippage_basis_points: Option<u64>,
+        priority_fee: Option<PriorityFee>,
+    ) -> Result<Signature, error::ClientError> {
+        // Add priority fee if provided or default to cluster priority fee
+        let priority_fee = priority_fee.unwrap_or(self.cluster.priority_fee);
+        let mut instructions = Self::get_priority_fee_instructions(&priority_fee);
 
-      // Add buy instruction
-      let buy_ix = self
-         .get_buy_instructions(mint, amount_sol, slippage_basis_points)
-         .await?;
-      instructions.extend(buy_ix);
+        // Add buy instruction
+        let buy_ix = self
+            .get_buy_instructions(mint, amount_sol, slippage_basis_points)
+            .await?;
+        instructions.extend(buy_ix);
 
-      // Create and sign transaction
-      let transaction = get_transaction(
-         self.rpc.clone(),
-         self.payer.clone(),
-         &instructions,
-         None,
-         #[cfg(feature = "versioned-tx")]
-         None,
-      )
-      .await?;
+        // Create and sign transaction
+        let transaction = get_transaction(
+            self.rpc.clone(),
+            self.payer.clone(),
+            &instructions,
+            None,
+            #[cfg(feature = "versioned-tx")]
+            None,
+        )
+        .await?;
 
-      // Send and confirm transaction
-      let signature = self
-         .rpc
-         .send_and_confirm_transaction(&transaction)
-         .await
-         .map_err(error::ClientError::SolanaClientError)?;
+        // Send and confirm transaction
+        let signature = self
+            .rpc
+            .send_and_confirm_transaction(&transaction)
+            .await
+            .map_err(error::ClientError::SolanaClientError)?;
 
-      Ok(signature)
-   }
+        Ok(signature)
+    }
 
-   /// Sells tokens back to the bonding curve in exchange for SOL
-   ///
-   /// This method sells tokens back to the bonding curve, receiving SOL in return. The amount of SOL
-   /// received is determined by the bonding curve formula for the specific token. As more tokens
-   /// are sold, the price decreases according to the curve function.
-   ///
-   /// The method:
-   /// 1. Determines how many tokens to sell (all tokens or a specific amount)
-   /// 2. Calculates how much SOL will be received for the tokens
-   /// 3. Executes the sell transaction with slippage protection
-   ///
-   /// A portion of the SOL is taken as a fee according to the global configuration.
-   ///
-   /// # Arguments
-   ///
-   /// * `mint` - Public key of the token mint to sell
-   /// * `amount_token` - Optional amount of tokens to sell in base units. If None, sells the entire balance
-   /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
-   ///                             If None, defaults to 500 (5%)
-   /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
-   ///                    default from the cluster configuration
-   ///
-   /// # Returns
-   ///
-   /// Returns the transaction signature if successful, or a ClientError if the operation fails
-   ///
-   /// # Errors
-   ///
-   /// Returns an error if:
-   /// - The token account cannot be found
-   /// - The bonding curve account cannot be found
-   /// - The sell price calculation fails
-   /// - Transaction creation fails
-   /// - Transaction execution on Solana fails
-   ///
-   /// # Examples
-   ///
-   /// ```no_run
-   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
-   /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair, pubkey};
-   /// # use std::sync::Arc;
-   /// #
-   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-   /// # let payer = Arc::new(Keypair::new());
-   /// # let commitment = CommitmentConfig::confirmed();
-   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-   /// # let client = PumpFun::new(payer, cluster);
-   /// let token_mint = pubkey!("SoMeTokenM1ntAddr3ssXXXXXXXXXXXXXXXXXXXXXXX");
-   ///
-   /// // Sell 1000 tokens with 2% max slippage
-   /// let amount_tokens = Some(1000);
-   /// let slippage_bps = Some(200); // 2%
-   ///
-   /// let signature = client.sell(token_mint, amount_tokens, slippage_bps, None).await?;
-   /// println!("Tokens sold! Signature: {}", signature);
-   ///
-   /// // Or sell all tokens with default slippage (5%)
-   /// let signature = client.sell(token_mint, None, None, None).await?;
-   /// println!("All tokens sold! Signature: {}", signature);
-   /// # Ok(())
-   /// # }
-   /// ```
-   pub async fn sell(
-      &self,
-      mint: Pubkey,
-      amount_token: Option<u64>,
-      slippage_basis_points: Option<u64>,
-      priority_fee: Option<PriorityFee>,
-   ) -> Result<Signature, error::ClientError> {
-      // Add priority fee if provided or default to cluster priority fee
-      let priority_fee = priority_fee.unwrap_or(self.cluster.priority_fee);
-      let mut instructions = Self::get_priority_fee_instructions(&priority_fee);
+    /// Sells tokens back to the bonding curve in exchange for SOL
+    ///
+    /// This method sells tokens back to the bonding curve, receiving SOL in return. The amount of SOL
+    /// received is determined by the bonding curve formula for the specific token. As more tokens
+    /// are sold, the price decreases according to the curve function.
+    ///
+    /// The method:
+    /// 1. Determines how many tokens to sell (all tokens or a specific amount)
+    /// 2. Calculates how much SOL will be received for the tokens
+    /// 3. Executes the sell transaction with slippage protection
+    ///
+    /// A portion of the SOL is taken as a fee according to the global configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `mint` - Public key of the token mint to sell
+    /// * `amount_token` - Optional amount of tokens to sell in base units. If None, sells the entire balance
+    /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
+    ///                             If None, defaults to 500 (5%)
+    /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
+    ///                    default from the cluster configuration
+    ///
+    /// # Returns
+    ///
+    /// Returns the transaction signature if successful, or a ClientError if the operation fails
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The token account cannot be found
+    /// - The bonding curve account cannot be found
+    /// - The sell price calculation fails
+    /// - Transaction creation fails
+    /// - Transaction execution on Solana fails
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
+    /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair, pubkey};
+    /// # use std::sync::Arc;
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let payer = Arc::new(Keypair::new());
+    /// # let commitment = CommitmentConfig::confirmed();
+    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+    /// # let client = PumpFun::new(payer, cluster);
+    /// let token_mint = pubkey!("SoMeTokenM1ntAddr3ssXXXXXXXXXXXXXXXXXXXXXXX");
+    ///
+    /// // Sell 1000 tokens with 2% max slippage
+    /// let amount_tokens = Some(1000);
+    /// let slippage_bps = Some(200); // 2%
+    ///
+    /// let signature = client.sell(token_mint, amount_tokens, slippage_bps, None).await?;
+    /// println!("Tokens sold! Signature: {}", signature);
+    ///
+    /// // Or sell all tokens with default slippage (5%)
+    /// let signature = client.sell(token_mint, None, None, None).await?;
+    /// println!("All tokens sold! Signature: {}", signature);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn sell(
+        &self,
+        mint: Pubkey,
+        amount_token: Option<u64>,
+        slippage_basis_points: Option<u64>,
+        priority_fee: Option<PriorityFee>,
+    ) -> Result<Signature, error::ClientError> {
+        // Add priority fee if provided or default to cluster priority fee
+        let priority_fee = priority_fee.unwrap_or(self.cluster.priority_fee);
+        let mut instructions = Self::get_priority_fee_instructions(&priority_fee);
 
-      // Add sell instruction
-      let sell_ix = self
-         .get_sell_instructions(mint, amount_token, slippage_basis_points)
-         .await?;
-      instructions.extend(sell_ix);
+        // Add sell instruction
+        let sell_ix = self
+            .get_sell_instructions(mint, amount_token, slippage_basis_points)
+            .await?;
+        instructions.extend(sell_ix);
 
-      // Create and sign transaction
-      let transaction = get_transaction(
-         self.rpc.clone(),
-         self.payer.clone(),
-         &instructions,
-         None,
-         #[cfg(feature = "versioned-tx")]
-         None,
-      )
-      .await?;
+        // Create and sign transaction
+        let transaction = get_transaction(
+            self.rpc.clone(),
+            self.payer.clone(),
+            &instructions,
+            None,
+            #[cfg(feature = "versioned-tx")]
+            None,
+        )
+        .await?;
 
-      // Send and confirm transaction
-      let signature = self
-         .rpc
-         .send_and_confirm_transaction(&transaction)
-         .await
-         .map_err(error::ClientError::SolanaClientError)?;
+        // Send and confirm transaction
+        let signature = self
+            .rpc
+            .send_and_confirm_transaction(&transaction)
+            .await
+            .map_err(error::ClientError::SolanaClientError)?;
 
-      Ok(signature)
-   }
+        Ok(signature)
+    }
 
-   /// Subscribes to real-time events from the Pump.fun program
-   ///
-   /// This method establishes a WebSocket connection to the Solana cluster and subscribes
-   /// to program log events from the Pump.fun program. It parses the emitted events into
-   /// structured data types and delivers them through the provided callback function.
-   ///
-   /// Event types include:
-   /// - `CreateEvent`: Emitted when a new token is created
-   /// - `TradeEvent`: Emitted when tokens are bought or sold
-   /// - `CompleteEvent`: Emitted when a bonding curve operation completes
-   /// - `SetParamsEvent`: Emitted when global parameters are updated
-   ///
-   /// # Arguments
-   ///
-   /// * `commitment` - Optional commitment level for the subscription. If None, uses the
-   ///                  default from the cluster configuration
-   /// * `callback` - A function that will be called for each event with the following parameters:
-   ///   * `signature`: The transaction signature as a String
-   ///   * `event`: The parsed PumpFunEvent if successful, or None if parsing failed
-   ///   * `error`: Any error that occurred during parsing, or None if successful
-   ///   * `response`: The complete RPC logs response for additional context
-   ///
-   /// # Returns
-   ///
-   /// Returns a `Subscription` object that manages the lifecycle of the subscription.
-   /// When this object is dropped, the subscription is automatically terminated. If
-   /// the subscription cannot be established, returns a ClientError.
-   ///
-   /// # Errors
-   ///
-   /// Returns an error if:
-   /// - The WebSocket connection cannot be established
-   /// - The subscription request fails
-   ///
-   /// # Examples
-   ///
-   /// ```no_run
-   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
-   /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
-   /// # use std::{sync::Arc, error::Error};
-   /// #
-   /// # async fn example() -> Result<(), Box<dyn Error>> {
-   /// # let payer = Arc::new(Keypair::new());
-   /// # let commitment = CommitmentConfig::confirmed();
-   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-   /// # let client = PumpFun::new(payer, cluster);
-   /// #
-   /// // Subscribe to token events
-   /// let subscription = client.subscribe(None, |signature, event, error, _| {
-   ///     match event {
-   ///         Some(pumpfun::common::stream::PumpFunEvent::Create(create_event)) => {
-   ///             println!("New token created: {} ({})", create_event.name, create_event.symbol);
-   ///             println!("Mint address: {}", create_event.mint);
-   ///         },
-   ///         Some(pumpfun::common::stream::PumpFunEvent::Trade(trade_event)) => {
-   ///             let action = if trade_event.is_buy { "bought" } else { "sold" };
-   ///             println!(
-   ///                 "User {} {} {} tokens for {} SOL",
-   ///                 trade_event.user,
-   ///                 action,
-   ///                 trade_event.token_amount,
-   ///                 trade_event.sol_amount as f64 / 1_000_000_000.0
-   ///             );
-   ///         },
-   ///         Some(event) => println!("Other event received: {:#?}", event),
-   ///         None => {
-   ///             if let Some(err) = error {
-   ///                 eprintln!("Error parsing event in tx {}: {}", signature, err);
-   ///             }
-   ///         }
-   ///     }
-   /// }).await?;
-   ///
-   /// // Keep the subscription active
-   /// // When no longer needed, drop the subscription to unsubscribe
-   /// # Ok(())
-   /// # }
-   /// ```
-   #[cfg(feature = "stream")]
-   pub async fn subscribe<F>(
-      &self,
-      commitment: Option<solana_sdk::commitment_config::CommitmentConfig>,
-      callback: F,
-   ) -> Result<common::stream::Subscription, error::ClientError>
-   where
-      F: Fn(
-            String,
-            Option<common::stream::PumpFunEvent>,
-            Option<Box<dyn std::error::Error>>,
-            solana_client::rpc_response::Response<solana_client::rpc_response::RpcLogsResponse>,
-         ) + Send
-         + Sync
-         + 'static,
-   {
-      common::stream::subscribe(self.cluster.clone(), commitment, callback).await
-   }
+    /// Subscribes to real-time events from the Pump.fun program
+    ///
+    /// This method establishes a WebSocket connection to the Solana cluster and subscribes
+    /// to program log events from the Pump.fun program. It parses the emitted events into
+    /// structured data types and delivers them through the provided callback function.
+    ///
+    /// Event types include:
+    /// - `CreateEvent`: Emitted when a new token is created
+    /// - `TradeEvent`: Emitted when tokens are bought or sold
+    /// - `CompleteEvent`: Emitted when a bonding curve operation completes
+    /// - `SetParamsEvent`: Emitted when global parameters are updated
+    ///
+    /// # Arguments
+    ///
+    /// * `commitment` - Optional commitment level for the subscription. If None, uses the
+    ///                  default from the cluster configuration
+    /// * `callback` - A function that will be called for each event with the following parameters:
+    ///   * `signature`: The transaction signature as a String
+    ///   * `event`: The parsed PumpFunEvent if successful, or None if parsing failed
+    ///   * `error`: Any error that occurred during parsing, or None if successful
+    ///   * `response`: The complete RPC logs response for additional context
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Subscription` object that manages the lifecycle of the subscription.
+    /// When this object is dropped, the subscription is automatically terminated. If
+    /// the subscription cannot be established, returns a ClientError.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The WebSocket connection cannot be established
+    /// - The subscription request fails
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
+    /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
+    /// # use std::{sync::Arc, error::Error};
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn Error>> {
+    /// # let payer = Arc::new(Keypair::new());
+    /// # let commitment = CommitmentConfig::confirmed();
+    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+    /// # let client = PumpFun::new(payer, cluster);
+    /// #
+    /// // Subscribe to token events
+    /// let subscription = client.subscribe(None, |signature, event, error, _| {
+    ///     match event {
+    ///         Some(pumpfun::common::stream::PumpFunEvent::Create(create_event)) => {
+    ///             println!("New token created: {} ({})", create_event.name, create_event.symbol);
+    ///             println!("Mint address: {}", create_event.mint);
+    ///         },
+    ///         Some(pumpfun::common::stream::PumpFunEvent::Trade(trade_event)) => {
+    ///             let action = if trade_event.is_buy { "bought" } else { "sold" };
+    ///             println!(
+    ///                 "User {} {} {} tokens for {} SOL",
+    ///                 trade_event.user,
+    ///                 action,
+    ///                 trade_event.token_amount,
+    ///                 trade_event.sol_amount as f64 / 1_000_000_000.0
+    ///             );
+    ///         },
+    ///         Some(event) => println!("Other event received: {:#?}", event),
+    ///         None => {
+    ///             if let Some(err) = error {
+    ///                 eprintln!("Error parsing event in tx {}: {}", signature, err);
+    ///             }
+    ///         }
+    ///     }
+    /// }).await?;
+    ///
+    /// // Keep the subscription active
+    /// // When no longer needed, drop the subscription to unsubscribe
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "stream")]
+    pub async fn subscribe<F>(
+        &self,
+        commitment: Option<solana_sdk::commitment_config::CommitmentConfig>,
+        callback: F,
+    ) -> Result<common::stream::Subscription, error::ClientError>
+    where
+        F: Fn(
+                String,
+                Option<common::stream::PumpFunEvent>,
+                Option<Box<dyn std::error::Error>>,
+                solana_client::rpc_response::Response<solana_client::rpc_response::RpcLogsResponse>,
+            ) + Send
+            + Sync
+            + 'static,
+    {
+        common::stream::subscribe(self.cluster.clone(), commitment, callback).await
+    }
 
-   /// Creates compute budget instructions for priority fees
-   ///
-   /// Generates Solana compute budget instructions based on the provided priority fee
-   /// configuration. These instructions are used to set the maximum compute units a
-   /// transaction can consume and the price per compute unit, which helps prioritize
-   /// transaction processing during network congestion.
-   ///
-   /// # Arguments
-   ///
-   /// * `priority_fee` - Priority fee configuration containing optional unit limit and unit price
-   ///
-   /// # Returns
-   ///
-   /// Returns a vector of instructions to set compute budget parameters, which can be
-   /// empty if no priority fee parameters are provided
-   ///
-   /// # Examples
-   ///
-   /// ```no_run
-   /// # use pumpfun::{PumpFun, common::types::PriorityFee};
-   /// # use solana_sdk::instruction::Instruction;
-   /// #
-   /// // Set both compute unit limit and price
-   /// let priority_fee = PriorityFee {
-   ///     unit_limit: Some(200_000),
-   ///     unit_price: Some(1_000), // 1000 micro-lamports per compute unit
-   /// };
-   ///
-   /// let compute_instructions: Vec<Instruction> = PumpFun::get_priority_fee_instructions(&priority_fee);
-   /// ```
-   pub fn get_priority_fee_instructions(priority_fee: &PriorityFee) -> Vec<Instruction> {
-      let mut instructions = Vec::new();
+    /// Creates compute budget instructions for priority fees
+    ///
+    /// Generates Solana compute budget instructions based on the provided priority fee
+    /// configuration. These instructions are used to set the maximum compute units a
+    /// transaction can consume and the price per compute unit, which helps prioritize
+    /// transaction processing during network congestion.
+    ///
+    /// # Arguments
+    ///
+    /// * `priority_fee` - Priority fee configuration containing optional unit limit and unit price
+    ///
+    /// # Returns
+    ///
+    /// Returns a vector of instructions to set compute budget parameters, which can be
+    /// empty if no priority fee parameters are provided
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use pumpfun::{PumpFun, common::types::PriorityFee};
+    /// # use solana_sdk::instruction::Instruction;
+    /// #
+    /// // Set both compute unit limit and price
+    /// let priority_fee = PriorityFee {
+    ///     unit_limit: Some(200_000),
+    ///     unit_price: Some(1_000), // 1000 micro-lamports per compute unit
+    /// };
+    ///
+    /// let compute_instructions: Vec<Instruction> = PumpFun::get_priority_fee_instructions(&priority_fee);
+    /// ```
+    pub fn get_priority_fee_instructions(priority_fee: &PriorityFee) -> Vec<Instruction> {
+        let mut instructions = Vec::new();
 
-      if let Some(limit) = priority_fee.unit_limit {
-         let limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(limit);
-         instructions.push(limit_ix);
-      }
+        if let Some(limit) = priority_fee.unit_limit {
+            let limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(limit);
+            instructions.push(limit_ix);
+        }
 
-      if let Some(price) = priority_fee.unit_price {
-         let price_ix = ComputeBudgetInstruction::set_compute_unit_price(price);
-         instructions.push(price_ix);
-      }
+        if let Some(price) = priority_fee.unit_price {
+            let price_ix = ComputeBudgetInstruction::set_compute_unit_price(price);
+            instructions.push(price_ix);
+        }
 
-      instructions
-   }
+        instructions
+    }
 
-   /// Creates an instruction for initializing a new token
-   ///
-   /// Generates a Solana instruction to create a new token with a bonding curve on Pump.fun.
-   /// This instruction will initialize the token mint, metadata, and bonding curve accounts.
-   ///
-   /// # Arguments
-   ///
-   /// * `mint` - Keypair for the new token mint account that will be created
-   /// * `ipfs` - Token metadata response from IPFS upload containing name, symbol, and URI
-   ///
-   /// # Returns
-   ///
-   /// Returns a Solana instruction for creating a new token
-   ///
-   /// # Examples
-   ///
-   /// ```no_run
-   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}, utils};
-   /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
-   /// # use std::sync::Arc;
-   /// #
-   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-   /// # let payer = Arc::new(Keypair::new());
-   /// # let commitment = CommitmentConfig::confirmed();
-   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-   /// # let client = PumpFun::new(payer, cluster);
-   /// #
-   /// let mint = Keypair::new();
-   /// let metadata_response = utils::create_token_metadata(
-   ///     utils::CreateTokenMetadata {
-   ///         name: "Example Token".to_string(),
-   ///         symbol: "EXTKN".to_string(),
-   ///         description: "An example token".to_string(),
-   ///         file: "path/to/image.png".to_string(),
-   ///         twitter: None,
-   ///         telegram: None,
-   ///         website: None,
-   ///     }
-   /// ).await?;
-   ///
-   /// let create_instruction = client.get_create_instruction(&mint, metadata_response);
-   /// # Ok(())
-   /// # }
-   /// ```
-   pub fn get_create_instruction(
-      &self,
-      mint: &Keypair,
-      ipfs: utils::TokenMetadataResponse,
-   ) -> Instruction {
-      instructions::create(
-         &self.payer,
-         mint,
-         instructions::Create {
-            name: ipfs.metadata.name,
-            symbol: ipfs.metadata.symbol,
-            uri: ipfs.metadata.image,
-            creator: self.payer.pubkey(),
-         },
-      )
-   }
+    /// Creates an instruction for initializing a new token
+    ///
+    /// Generates a Solana instruction to create a new token with a bonding curve on Pump.fun.
+    /// This instruction will initialize the token mint, metadata, and bonding curve accounts.
+    ///
+    /// # Arguments
+    ///
+    /// * `mint` - Keypair for the new token mint account that will be created
+    /// * `ipfs` - Token metadata response from IPFS upload containing name, symbol, and URI
+    ///
+    /// # Returns
+    ///
+    /// Returns a Solana instruction for creating a new token
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}, utils};
+    /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
+    /// # use std::sync::Arc;
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let payer = Arc::new(Keypair::new());
+    /// # let commitment = CommitmentConfig::confirmed();
+    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+    /// # let client = PumpFun::new(payer, cluster);
+    /// #
+    /// let mint = Keypair::new();
+    /// let metadata_response = utils::create_token_metadata(
+    ///     utils::CreateTokenMetadata {
+    ///         name: "Example Token".to_string(),
+    ///         symbol: "EXTKN".to_string(),
+    ///         description: "An example token".to_string(),
+    ///         file: "path/to/image.png".to_string(),
+    ///         twitter: None,
+    ///         telegram: None,
+    ///         website: None,
+    ///     }
+    /// ).await?;
+    ///
+    /// let create_instruction = client.get_create_instruction(&mint, metadata_response);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get_create_instruction(
+        &self,
+        mint: &Keypair,
+        ipfs: utils::TokenMetadataResponse,
+    ) -> Instruction {
+        instructions::create(
+            &self.payer,
+            mint,
+            instructions::Create {
+                name: ipfs.metadata.name,
+                symbol: ipfs.metadata.symbol,
+                uri: ipfs.metadata.image,
+                creator: self.payer.pubkey(),
+            },
+        )
+    }
 
-   /// Generates instructions for buying tokens from a bonding curve
-   ///
-   /// Creates a set of Solana instructions needed to purchase tokens using SOL. These
-   /// instructions may include creating an associated token account if needed, and the actual
-   /// buy instruction with slippage protection.
-   ///
-   /// # Arguments
-   ///
-   /// * `mint` - Public key of the token mint to buy
-   /// * `amount_sol` - Amount of SOL to spend, in lamports (1 SOL = 1,000,000,000 lamports)
-   /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
-   ///                             If None, defaults to 500 (5%)
-   ///
-   /// # Returns
-   ///
-   /// Returns a vector of Solana instructions if successful, or a ClientError if the operation fails
-   ///
-   /// # Errors
-   ///
-   /// Returns an error if:
-   /// - The global account or bonding curve account cannot be fetched
-   /// - The buy price calculation fails
-   /// - Token account-related operations fail
-   ///
-   /// # Examples
-   ///
-   /// ```no_run
-   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
-   /// # use solana_sdk::{commitment_config::CommitmentConfig, native_token::sol_to_lamports, signature::Keypair, pubkey};
-   /// # use std::sync::Arc;
-   /// #
-   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-   /// # let payer = Arc::new(Keypair::new());
-   /// # let commitment = CommitmentConfig::confirmed();
-   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-   /// # let client = PumpFun::new(payer, cluster);
-   /// #
-   /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
-   /// let amount_sol = sol_to_lamports(0.01); // 0.01 SOL
-   /// let slippage_bps = Some(300); // 3%
-   ///
-   /// let buy_instructions = client.get_buy_instructions(mint, amount_sol, slippage_bps).await?;
-   /// # Ok(())
-   /// # }
-   /// ```
-   pub async fn get_buy_instructions(
-      &self,
-      mint: Pubkey,
-      amount_sol: u64,
-      slippage_basis_points: Option<u64>,
-   ) -> Result<Vec<Instruction>, error::ClientError> {
-      // Get accounts and calculate buy amounts
-      let global_account = self.get_global_account().await?;
-      let bonding_curve_account = self.get_bonding_curve_account(&mint).await?;
-      let buy_amount = bonding_curve_account
-         .get_buy_price(amount_sol)
-         .map_err(error::ClientError::BondingCurveError)?;
-      let buy_amount_with_slippage =
-         utils::calculate_with_slippage_buy(amount_sol, slippage_basis_points.unwrap_or(500));
+    /// Generates instructions for buying tokens from a bonding curve
+    ///
+    /// Creates a set of Solana instructions needed to purchase tokens using SOL. These
+    /// instructions may include creating an associated token account if needed, and the actual
+    /// buy instruction with slippage protection.
+    ///
+    /// # Arguments
+    ///
+    /// * `mint` - Public key of the token mint to buy
+    /// * `amount_sol` - Amount of SOL to spend, in lamports (1 SOL = 1,000,000,000 lamports)
+    /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
+    ///                             If None, defaults to 500 (5%)
+    ///
+    /// # Returns
+    ///
+    /// Returns a vector of Solana instructions if successful, or a ClientError if the operation fails
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The global account or bonding curve account cannot be fetched
+    /// - The buy price calculation fails
+    /// - Token account-related operations fail
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
+    /// # use solana_sdk::{commitment_config::CommitmentConfig, native_token::sol_to_lamports, signature::Keypair, pubkey};
+    /// # use std::sync::Arc;
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let payer = Arc::new(Keypair::new());
+    /// # let commitment = CommitmentConfig::confirmed();
+    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+    /// # let client = PumpFun::new(payer, cluster);
+    /// #
+    /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    /// let amount_sol = sol_to_lamports(0.01); // 0.01 SOL
+    /// let slippage_bps = Some(300); // 3%
+    ///
+    /// let buy_instructions = client.get_buy_instructions(mint, amount_sol, slippage_bps).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_buy_instructions(
+        &self,
+        mint: Pubkey,
+        amount_sol: u64,
+        slippage_basis_points: Option<u64>,
+    ) -> Result<Vec<Instruction>, error::ClientError> {
+        // Get accounts and calculate buy amounts
+        let global_account = self.get_global_account().await?;
+        let bonding_curve_account = self.get_bonding_curve_account(&mint).await?;
+        let buy_amount = bonding_curve_account
+            .get_buy_price(amount_sol)
+            .map_err(error::ClientError::BondingCurveError)?;
+        let buy_amount_with_slippage =
+            utils::calculate_with_slippage_buy(amount_sol, slippage_basis_points.unwrap_or(500));
 
-      let mut instructions = Vec::new();
+        let mut instructions = Vec::new();
 
-      // Create Associated Token Account if needed
-      #[cfg(feature = "create-ata")]
-      {
-         let ata: Pubkey = get_associated_token_address(&self.payer.pubkey(), &mint);
-         if self.rpc.get_account(&ata).await.is_err() {
-            instructions.push(create_associated_token_account(
-               &self.payer.pubkey(),
-               &self.payer.pubkey(),
-               &mint,
-               &constants::accounts::TOKEN_PROGRAM,
-            ));
-         }
-      }
-
-      // Add buy instruction
-      instructions.push(instructions::buy(
-         &self.payer,
-         &mint,
-         &global_account.fee_recipient,
-         &bonding_curve_account.creator,
-         instructions::Buy {
-            amount: buy_amount,
-            max_sol_cost: buy_amount_with_slippage,
-         },
-      ));
-
-      Ok(instructions)
-   }
-
-   /// Generates instructions for selling tokens back to a bonding curve
-   ///
-   /// Creates a set of Solana instructions needed to sell tokens in exchange for SOL. These
-   /// instructions include the sell instruction with slippage protection and may include
-   /// closing the associated token account if all tokens are being sold and the feature
-   /// is enabled.
-   ///
-   /// # Arguments
-   ///
-   /// * `mint` - Public key of the token mint to sell
-   /// * `amount_token` - Optional amount of tokens to sell in base units. If None, sells the entire balance
-   /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
-   ///                             If None, defaults to 500 (5%)
-   ///
-   /// # Returns
-   ///
-   /// Returns a vector of Solana instructions if successful, or a ClientError if the operation fails
-   ///
-   /// # Errors
-   ///
-   /// Returns an error if:
-   /// - The token account or token balance cannot be fetched
-   /// - The global account or bonding curve account cannot be fetched
-   /// - The sell price calculation fails
-   /// - Token account closing operations fail (when applicable)
-   ///
-   /// # Examples
-   ///
-   /// ```no_run
-   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
-   /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair, pubkey};
-   /// # use std::sync::Arc;
-   /// #
-   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-   /// # let payer = Arc::new(Keypair::new());
-   /// # let commitment = CommitmentConfig::confirmed();
-   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-   /// # let client = PumpFun::new(payer, cluster);
-   /// #
-   /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
-   /// let amount_tokens = Some(1000); // Sell 1000 tokens
-   /// let slippage_bps = Some(200); // 2%
-   ///
-   /// let sell_instructions = client.get_sell_instructions(mint, amount_tokens, slippage_bps).await?;
-   ///
-   /// // Or to sell all tokens:
-   /// let sell_all_instructions = client.get_sell_instructions(mint, None, None).await?;
-   /// # Ok(())
-   /// # }
-   /// ```
-   pub async fn get_sell_instructions(
-      &self,
-      mint: Pubkey,
-      amount_token: Option<u64>,
-      slippage_basis_points: Option<u64>,
-   ) -> Result<Vec<Instruction>, error::ClientError> {
-      // Get ATA
-      let ata: Pubkey = get_associated_token_address(&self.payer.pubkey(), &mint);
-
-      // Get token balance
-      let token_balance = if amount_token.is_none() || cfg!(feature = "close-ata") {
-         // We need the balance if amount_token is None OR if the close-ata feature is enabled
-         let balance = self.rpc.get_token_account_balance(&ata).await?;
-         Some(balance.amount.parse::<u64>().unwrap())
-      } else {
-         None
-      };
-
-      // Determine amount to sell
-      let amount = amount_token.unwrap_or_else(|| token_balance.unwrap());
-
-      // Calculate min sol output
-      let global_account = self.get_global_account().await?;
-      let bonding_curve_account = self.get_bonding_curve_account(&mint).await?;
-      let min_sol_output = bonding_curve_account
-         .get_sell_price(amount, global_account.fee_basis_points)
-         .map_err(error::ClientError::BondingCurveError)?;
-      let min_sol_output =
-         utils::calculate_with_slippage_sell(min_sol_output, slippage_basis_points.unwrap_or(500));
-
-      let mut instructions = Vec::new();
-
-      // Add sell instruction
-      instructions.push(instructions::sell(
-         &self.payer,
-         &mint,
-         &global_account.fee_recipient,
-         &bonding_curve_account.creator,
-         instructions::Sell {
-            amount,
-            min_sol_output,
-         },
-      ));
-
-      // Close account if balance equals amount
-      #[cfg(feature = "close-ata")]
-      {
-         // Token balance should be guaranteed to be available at this point
-         // due to our fetch logic in the beginning of the function
-         if let Some(balance) = token_balance {
-            // Only close the account if we're selling all tokens
-            if balance == amount {
-               let token_program = constants::accounts::TOKEN_PROGRAM;
-
-               // Verify the token account exists before attempting to close it
-               if self.rpc.get_account(&ata).await.is_ok() {
-                  // Create instruction to close the ATA
-                  let close_instruction = close_account(
-                     &token_program,
-                     &ata,
-                     &self.payer.pubkey(),
-                     &self.payer.pubkey(),
-                     &[&self.payer.pubkey()],
-                  )
-                  .map_err(|err| {
-                     error::ClientError::OtherError(format!(
-                        "Failed to create close account instruction: pubkey={}: {}",
-                        ata, err
-                     ))
-                  })?;
-
-                  instructions.push(close_instruction);
-               } else {
-                  // Log warning but don't fail the transaction if account doesn't exist
-                  eprintln!(
-                     "Warning: Cannot close token account {}, it doesn't exist",
-                     ata
-                  );
-               }
+        // Create Associated Token Account if needed
+        #[cfg(feature = "create-ata")]
+        {
+            let ata: Pubkey = get_associated_token_address(&self.payer.pubkey(), &mint);
+            if self.rpc.get_account(&ata).await.is_err() {
+                instructions.push(create_associated_token_account(
+                    &self.payer.pubkey(),
+                    &self.payer.pubkey(),
+                    &mint,
+                    &constants::accounts::TOKEN_PROGRAM,
+                ));
             }
-         } else {
-            // This case should not occur due to our balance fetch logic,
-            // but handle it gracefully just in case
-            eprintln!("Warning: Token balance unavailable, not closing account");
-         }
-      }
+        }
 
-      Ok(instructions)
-   }
+        // Add buy instruction
+        instructions.push(instructions::buy(
+            &self.payer,
+            &mint,
+            &global_account.fee_recipient,
+            &bonding_curve_account.creator,
+            instructions::Buy {
+                amount: buy_amount,
+                max_sol_cost: buy_amount_with_slippage,
+            },
+        ));
 
-   /// Gets the Program Derived Address (PDA) for the global state account
-   ///
-   /// Derives the address of the global state account using the program ID and a
-   /// constant seed. The global state account contains program-wide configuration
-   /// such as fee settings and fee recipient.
-   ///
-   /// # Returns
-   ///
-   /// Returns the PDA public key derived from the GLOBAL_SEED
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// # use pumpfun::PumpFun;
-   /// # use solana_sdk::pubkey::Pubkey;
-   /// #
-   /// let global_pda: Pubkey = PumpFun::get_global_pda();
-   /// println!("Global state account: {}", global_pda);
-   /// ```
-   pub fn get_global_pda() -> Pubkey {
-      let seeds: &[&[u8]; 1] = &[constants::seeds::GLOBAL_SEED];
-      let program_id: &Pubkey = &constants::accounts::PUMPFUN;
-      Pubkey::find_program_address(seeds, program_id).0
-   }
+        Ok(instructions)
+    }
 
-   /// Gets the Program Derived Address (PDA) for the mint authority
-   ///
-   /// Derives the address of the mint authority PDA using the program ID and a
-   /// constant seed. The mint authority PDA is the authority that can mint new
-   /// tokens for any token created through the Pump.fun program.
-   ///
-   /// # Returns
-   ///
-   /// Returns the PDA public key derived from the MINT_AUTHORITY_SEED
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// # use pumpfun::PumpFun;
-   /// # use solana_sdk::pubkey::Pubkey;
-   /// #
-   /// let mint_authority: Pubkey = PumpFun::get_mint_authority_pda();
-   /// println!("Mint authority account: {}", mint_authority);
-   /// ```
-   pub fn get_mint_authority_pda() -> Pubkey {
-      let seeds: &[&[u8]; 1] = &[constants::seeds::MINT_AUTHORITY_SEED];
-      let program_id: &Pubkey = &constants::accounts::PUMPFUN;
-      Pubkey::find_program_address(seeds, program_id).0
-   }
+    /// Generates instructions for selling tokens back to a bonding curve
+    ///
+    /// Creates a set of Solana instructions needed to sell tokens in exchange for SOL. These
+    /// instructions include the sell instruction with slippage protection and may include
+    /// closing the associated token account if all tokens are being sold and the feature
+    /// is enabled.
+    ///
+    /// # Arguments
+    ///
+    /// * `mint` - Public key of the token mint to sell
+    /// * `amount_token` - Optional amount of tokens to sell in base units. If None, sells the entire balance
+    /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
+    ///                             If None, defaults to 500 (5%)
+    ///
+    /// # Returns
+    ///
+    /// Returns a vector of Solana instructions if successful, or a ClientError if the operation fails
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The token account or token balance cannot be fetched
+    /// - The global account or bonding curve account cannot be fetched
+    /// - The sell price calculation fails
+    /// - Token account closing operations fail (when applicable)
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
+    /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair, pubkey};
+    /// # use std::sync::Arc;
+    /// #
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let payer = Arc::new(Keypair::new());
+    /// # let commitment = CommitmentConfig::confirmed();
+    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+    /// # let client = PumpFun::new(payer, cluster);
+    /// #
+    /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    /// let amount_tokens = Some(1000); // Sell 1000 tokens
+    /// let slippage_bps = Some(200); // 2%
+    ///
+    /// let sell_instructions = client.get_sell_instructions(mint, amount_tokens, slippage_bps).await?;
+    ///
+    /// // Or to sell all tokens:
+    /// let sell_all_instructions = client.get_sell_instructions(mint, None, None).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_sell_instructions(
+        &self,
+        mint: Pubkey,
+        amount_token: Option<u64>,
+        slippage_basis_points: Option<u64>,
+    ) -> Result<Vec<Instruction>, error::ClientError> {
+        // Get ATA
+        let ata: Pubkey = get_associated_token_address(&self.payer.pubkey(), &mint);
 
-   /// Gets the Program Derived Address (PDA) for a token's bonding curve account
-   ///
-   /// Derives the address of a token's bonding curve account using the program ID,
-   /// a constant seed, and the token mint address. The bonding curve account stores
-   /// the state and parameters that govern the token's price dynamics.
-   ///
-   /// # Arguments
-   ///
-   /// * `mint` - Public key of the token mint
-   ///
-   /// # Returns
-   ///
-   /// Returns Some(PDA) if derivation succeeds, or None if it fails
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// # use pumpfun::PumpFun;
-   /// # use solana_sdk::{pubkey, pubkey::Pubkey};
-   /// #
-   /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
-   /// if let Some(bonding_curve) = PumpFun::get_bonding_curve_pda(&mint) {
-   ///     println!("Bonding curve account: {}", bonding_curve);
-   /// }
-   /// ```
-   pub fn get_bonding_curve_pda(mint: &Pubkey) -> Option<Pubkey> {
-      let seeds: &[&[u8]; 2] = &[constants::seeds::BONDING_CURVE_SEED, mint.as_ref()];
-      let program_id: &Pubkey = &constants::accounts::PUMPFUN;
-      let pda: Option<(Pubkey, u8)> = Pubkey::try_find_program_address(seeds, program_id);
-      pda.map(|pubkey| pubkey.0)
-   }
+        // Get token balance
+        let token_balance = if amount_token.is_none() || cfg!(feature = "close-ata") {
+            // We need the balance if amount_token is None OR if the close-ata feature is enabled
+            let balance = self.rpc.get_token_account_balance(&ata).await?;
+            Some(balance.amount.parse::<u64>().unwrap())
+        } else {
+            None
+        };
 
-   /// Gets the Program Derived Address (PDA) for a token's metadata account
-   ///
-   /// Derives the address of a token's metadata account following the Metaplex Token Metadata
-   /// standard. The metadata account stores information about the token such as name,
-   /// symbol, and URI pointing to additional metadata.
-   ///
-   /// # Arguments
-   ///
-   /// * `mint` - Public key of the token mint
-   ///
-   /// # Returns
-   ///
-   /// Returns the PDA public key for the token's metadata account
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// # use pumpfun::PumpFun;
-   /// # use solana_sdk::{pubkey, pubkey::Pubkey};
-   /// #
-   /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
-   /// let metadata_pda = PumpFun::get_metadata_pda(&mint);
-   /// println!("Token metadata account: {}", metadata_pda);
-   /// ```
-   pub fn get_metadata_pda(mint: &Pubkey) -> Pubkey {
-      let seeds: &[&[u8]; 3] = &[
-         constants::seeds::METADATA_SEED,
-         constants::accounts::MPL_TOKEN_METADATA.as_ref(),
-         mint.as_ref(),
-      ];
-      let program_id: &Pubkey = &constants::accounts::MPL_TOKEN_METADATA;
-      Pubkey::find_program_address(seeds, program_id).0
-   }
+        // Determine amount to sell
+        let amount = amount_token.unwrap_or_else(|| token_balance.unwrap());
 
-   /// Gets the global state account data containing program-wide configuration
-   ///
-   /// Fetches and deserializes the global state account which contains program-wide
-   /// configuration parameters such as:
-   /// - Fee basis points for trading
-   /// - Fee recipient account
-   /// - Bonding curve parameters
-   /// - Other platform-wide settings
-   ///
-   /// # Returns
-   ///
-   /// Returns the deserialized GlobalAccount if successful, or a ClientError if the operation fails
-   ///
-   /// # Errors
-   ///
-   /// Returns an error if:
-   /// - The account cannot be found on-chain
-   /// - The account data cannot be properly deserialized
-   ///
-   /// # Examples
-   ///
-   /// ```no_run
-   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
-   /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
-   /// # use std::sync::Arc;
-   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-   /// # let payer = Arc::new(Keypair::new());
-   /// # let commitment = CommitmentConfig::confirmed();
-   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-   /// # let client = PumpFun::new(payer, cluster);
-   /// let global = client.get_global_account().await?;
-   /// println!("Fee basis points: {}", global.fee_basis_points);
-   /// println!("Fee recipient: {}", global.fee_recipient);
-   /// # Ok(())
-   /// # }
-   /// ```
-   pub async fn get_global_account(&self) -> Result<accounts::GlobalAccount, error::ClientError> {
-      let global: Pubkey = Self::get_global_pda();
+        // Calculate min sol output
+        let global_account = self.get_global_account().await?;
+        let bonding_curve_account = self.get_bonding_curve_account(&mint).await?;
+        let min_sol_output = bonding_curve_account
+            .get_sell_price(amount, global_account.fee_basis_points)
+            .map_err(error::ClientError::BondingCurveError)?;
+        let min_sol_output = utils::calculate_with_slippage_sell(
+            min_sol_output,
+            slippage_basis_points.unwrap_or(500),
+        );
 
-      let account = self
-         .rpc
-         .get_account(&global)
-         .await
-         .map_err(error::ClientError::SolanaClientError)?;
+        let mut instructions = Vec::new();
 
-      solana_sdk::borsh1::try_from_slice_unchecked::<accounts::GlobalAccount>(&account.data)
-         .map_err(error::ClientError::BorshError)
-   }
+        // Add sell instruction
+        instructions.push(instructions::sell(
+            &self.payer,
+            &mint,
+            &global_account.fee_recipient,
+            &bonding_curve_account.creator,
+            instructions::Sell {
+                amount,
+                min_sol_output,
+            },
+        ));
 
-   /// Gets a token's bonding curve account data containing pricing parameters
-   ///
-   /// Fetches and deserializes a token's bonding curve account which contains the
-   /// state and parameters that determine the token's price dynamics, including:
-   /// - Current supply
-   /// - Reserve balance
-   /// - Bonding curve parameters
-   /// - Other token-specific configuration
-   ///
-   /// # Arguments
-   ///
-   /// * `mint` - Public key of the token mint
-   ///
-   /// # Returns
-   ///
-   /// Returns the deserialized BondingCurveAccount if successful, or a ClientError if the operation fails
-   ///
-   /// # Errors
-   ///
-   /// Returns an error if:
-   /// - The bonding curve PDA cannot be derived
-   /// - The account cannot be found on-chain
-   /// - The account data cannot be properly deserialized
-   ///
-   /// # Examples
-   ///
-   /// ```no_run
-   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
-   /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair, pubkey};
-   /// # use std::sync::Arc;
-   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-   /// # let payer = Arc::new(Keypair::new());
-   /// # let commitment = CommitmentConfig::confirmed();
-   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-   /// # let client = PumpFun::new(payer, cluster);
-   /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
-   /// let bonding_curve = client.get_bonding_curve_account(&mint).await?;
-   /// println!("Bonding Curve Account: {:#?}", bonding_curve);
-   /// # Ok(())
-   /// # }
-   /// ```
-   pub async fn get_bonding_curve_account(
-      &self,
-      mint: &Pubkey,
-   ) -> Result<accounts::BondingCurveAccount, error::ClientError> {
-      let bonding_curve_pda =
-         Self::get_bonding_curve_pda(mint).ok_or(error::ClientError::BondingCurveNotFound)?;
+        // Close account if balance equals amount
+        #[cfg(feature = "close-ata")]
+        {
+            // Token balance should be guaranteed to be available at this point
+            // due to our fetch logic in the beginning of the function
+            if let Some(balance) = token_balance {
+                // Only close the account if we're selling all tokens
+                if balance == amount {
+                    let token_program = constants::accounts::TOKEN_PROGRAM;
 
-      let account = self
-         .rpc
-         .get_account(&bonding_curve_pda)
-         .await
-         .map_err(error::ClientError::SolanaClientError)?;
+                    // Verify the token account exists before attempting to close it
+                    if self.rpc.get_account(&ata).await.is_ok() {
+                        // Create instruction to close the ATA
+                        let close_instruction = close_account(
+                            &token_program,
+                            &ata,
+                            &self.payer.pubkey(),
+                            &self.payer.pubkey(),
+                            &[&self.payer.pubkey()],
+                        )
+                        .map_err(|err| {
+                            error::ClientError::OtherError(format!(
+                                "Failed to create close account instruction: pubkey={}: {}",
+                                ata, err
+                            ))
+                        })?;
 
-      solana_sdk::borsh1::try_from_slice_unchecked::<accounts::BondingCurveAccount>(&account.data)
-         .map_err(error::ClientError::BorshError)
-   }
+                        instructions.push(close_instruction);
+                    } else {
+                        // Log warning but don't fail the transaction if account doesn't exist
+                        eprintln!(
+                            "Warning: Cannot close token account {}, it doesn't exist",
+                            ata
+                        );
+                    }
+                }
+            } else {
+                // This case should not occur due to our balance fetch logic,
+                // but handle it gracefully just in case
+                eprintln!("Warning: Token balance unavailable, not closing account");
+            }
+        }
 
-   /// Gets the creator vault address (for claiming pump creator fees)
-   ///
-   /// Derives the token creator's vault using the program ID,
-   /// a constant seed, and the creator's address.
-   ///
-   /// # Arguments
-   ///
-   /// * `creator` - Public key of the token's creator
-   ///
-   /// # Returns
-   ///
-   /// Returns Some(PDA) if derivation succeeds, or None if it fails
-   ///
-   /// # Examples
-   ///
-   /// ```
-   /// # use pumpfun::PumpFun;
-   /// # use solana_sdk::{pubkey, pubkey::Pubkey};
-   /// #
-   /// let creator = pubkey!("Amya8kr2bzEY9kyXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
-   /// if let Some(bonding_curve) = PumpFun::get_creator_vault_pda(&creator) {
-   ///     println!("Creator vault address: {}", creator vault);
-   /// }
-   /// ```
-   pub fn get_creator_vault_pda(creator: &Pubkey) -> Option<Pubkey> {
-      let seeds: &[&[u8]; 2] = &[constants::seeds::CREATOR_VAULT_SEED, creator.as_ref()];
-      let program_id: &Pubkey = &constants::accounts::PUMPFUN;
-      let pda: Option<(Pubkey, u8)> = Pubkey::try_find_program_address(seeds, program_id);
-      pda.map(|pubkey| pubkey.0)
-   }
+        Ok(instructions)
+    }
+
+    /// Gets the Program Derived Address (PDA) for the global state account
+    ///
+    /// Derives the address of the global state account using the program ID and a
+    /// constant seed. The global state account contains program-wide configuration
+    /// such as fee settings and fee recipient.
+    ///
+    /// # Returns
+    ///
+    /// Returns the PDA public key derived from the GLOBAL_SEED
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use pumpfun::PumpFun;
+    /// # use solana_sdk::pubkey::Pubkey;
+    /// #
+    /// let global_pda: Pubkey = PumpFun::get_global_pda();
+    /// println!("Global state account: {}", global_pda);
+    /// ```
+    pub fn get_global_pda() -> Pubkey {
+        let seeds: &[&[u8]; 1] = &[constants::seeds::GLOBAL_SEED];
+        let program_id: &Pubkey = &constants::accounts::PUMPFUN;
+        Pubkey::find_program_address(seeds, program_id).0
+    }
+
+    /// Gets the Program Derived Address (PDA) for the mint authority
+    ///
+    /// Derives the address of the mint authority PDA using the program ID and a
+    /// constant seed. The mint authority PDA is the authority that can mint new
+    /// tokens for any token created through the Pump.fun program.
+    ///
+    /// # Returns
+    ///
+    /// Returns the PDA public key derived from the MINT_AUTHORITY_SEED
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use pumpfun::PumpFun;
+    /// # use solana_sdk::pubkey::Pubkey;
+    /// #
+    /// let mint_authority: Pubkey = PumpFun::get_mint_authority_pda();
+    /// println!("Mint authority account: {}", mint_authority);
+    /// ```
+    pub fn get_mint_authority_pda() -> Pubkey {
+        let seeds: &[&[u8]; 1] = &[constants::seeds::MINT_AUTHORITY_SEED];
+        let program_id: &Pubkey = &constants::accounts::PUMPFUN;
+        Pubkey::find_program_address(seeds, program_id).0
+    }
+
+    /// Gets the Program Derived Address (PDA) for a token's bonding curve account
+    ///
+    /// Derives the address of a token's bonding curve account using the program ID,
+    /// a constant seed, and the token mint address. The bonding curve account stores
+    /// the state and parameters that govern the token's price dynamics.
+    ///
+    /// # Arguments
+    ///
+    /// * `mint` - Public key of the token mint
+    ///
+    /// # Returns
+    ///
+    /// Returns Some(PDA) if derivation succeeds, or None if it fails
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use pumpfun::PumpFun;
+    /// # use solana_sdk::{pubkey, pubkey::Pubkey};
+    /// #
+    /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    /// if let Some(bonding_curve) = PumpFun::get_bonding_curve_pda(&mint) {
+    ///     println!("Bonding curve account: {}", bonding_curve);
+    /// }
+    /// ```
+    pub fn get_bonding_curve_pda(mint: &Pubkey) -> Option<Pubkey> {
+        let seeds: &[&[u8]; 2] = &[constants::seeds::BONDING_CURVE_SEED, mint.as_ref()];
+        let program_id: &Pubkey = &constants::accounts::PUMPFUN;
+        let pda: Option<(Pubkey, u8)> = Pubkey::try_find_program_address(seeds, program_id);
+        pda.map(|pubkey| pubkey.0)
+    }
+
+    /// Gets the Program Derived Address (PDA) for a token's metadata account
+    ///
+    /// Derives the address of a token's metadata account following the Metaplex Token Metadata
+    /// standard. The metadata account stores information about the token such as name,
+    /// symbol, and URI pointing to additional metadata.
+    ///
+    /// # Arguments
+    ///
+    /// * `mint` - Public key of the token mint
+    ///
+    /// # Returns
+    ///
+    /// Returns the PDA public key for the token's metadata account
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use pumpfun::PumpFun;
+    /// # use solana_sdk::{pubkey, pubkey::Pubkey};
+    /// #
+    /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    /// let metadata_pda = PumpFun::get_metadata_pda(&mint);
+    /// println!("Token metadata account: {}", metadata_pda);
+    /// ```
+    pub fn get_metadata_pda(mint: &Pubkey) -> Pubkey {
+        let seeds: &[&[u8]; 3] = &[
+            constants::seeds::METADATA_SEED,
+            constants::accounts::MPL_TOKEN_METADATA.as_ref(),
+            mint.as_ref(),
+        ];
+        let program_id: &Pubkey = &constants::accounts::MPL_TOKEN_METADATA;
+        Pubkey::find_program_address(seeds, program_id).0
+    }
+
+    /// Gets the global state account data containing program-wide configuration
+    ///
+    /// Fetches and deserializes the global state account which contains program-wide
+    /// configuration parameters such as:
+    /// - Fee basis points for trading
+    /// - Fee recipient account
+    /// - Bonding curve parameters
+    /// - Other platform-wide settings
+    ///
+    /// # Returns
+    ///
+    /// Returns the deserialized GlobalAccount if successful, or a ClientError if the operation fails
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The account cannot be found on-chain
+    /// - The account data cannot be properly deserialized
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
+    /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
+    /// # use std::sync::Arc;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let payer = Arc::new(Keypair::new());
+    /// # let commitment = CommitmentConfig::confirmed();
+    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+    /// # let client = PumpFun::new(payer, cluster);
+    /// let global = client.get_global_account().await?;
+    /// println!("Fee basis points: {}", global.fee_basis_points);
+    /// println!("Fee recipient: {}", global.fee_recipient);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_global_account(&self) -> Result<accounts::GlobalAccount, error::ClientError> {
+        let global: Pubkey = Self::get_global_pda();
+
+        let account = self
+            .rpc
+            .get_account(&global)
+            .await
+            .map_err(error::ClientError::SolanaClientError)?;
+
+        solana_sdk::borsh1::try_from_slice_unchecked::<accounts::GlobalAccount>(&account.data)
+            .map_err(error::ClientError::BorshError)
+    }
+
+    /// Gets a token's bonding curve account data containing pricing parameters
+    ///
+    /// Fetches and deserializes a token's bonding curve account which contains the
+    /// state and parameters that determine the token's price dynamics, including:
+    /// - Current supply
+    /// - Reserve balance
+    /// - Bonding curve parameters
+    /// - Other token-specific configuration
+    ///
+    /// # Arguments
+    ///
+    /// * `mint` - Public key of the token mint
+    ///
+    /// # Returns
+    ///
+    /// Returns the deserialized BondingCurveAccount if successful, or a ClientError if the operation fails
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The bonding curve PDA cannot be derived
+    /// - The account cannot be found on-chain
+    /// - The account data cannot be properly deserialized
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
+    /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair, pubkey};
+    /// # use std::sync::Arc;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let payer = Arc::new(Keypair::new());
+    /// # let commitment = CommitmentConfig::confirmed();
+    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+    /// # let client = PumpFun::new(payer, cluster);
+    /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    /// let bonding_curve = client.get_bonding_curve_account(&mint).await?;
+    /// println!("Bonding Curve Account: {:#?}", bonding_curve);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_bonding_curve_account(
+        &self,
+        mint: &Pubkey,
+    ) -> Result<accounts::BondingCurveAccount, error::ClientError> {
+        let bonding_curve_pda =
+            Self::get_bonding_curve_pda(mint).ok_or(error::ClientError::BondingCurveNotFound)?;
+
+        let account = self
+            .rpc
+            .get_account(&bonding_curve_pda)
+            .await
+            .map_err(error::ClientError::SolanaClientError)?;
+
+        solana_sdk::borsh1::try_from_slice_unchecked::<accounts::BondingCurveAccount>(&account.data)
+            .map_err(error::ClientError::BorshError)
+    }
+
+    /// Gets the creator vault address (for claiming pump creator fees)
+    ///
+    /// Derives the token creator's vault using the program ID,
+    /// a constant seed, and the creator's address.
+    ///
+    /// # Arguments
+    ///
+    /// * `creator` - Public key of the token's creator
+    ///
+    /// # Returns
+    ///
+    /// Returns Some(PDA) if derivation succeeds, or None if it fails
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use pumpfun::PumpFun;
+    /// # use solana_sdk::{pubkey, pubkey::Pubkey};
+    /// #
+    /// let creator = pubkey!("Amya8kr2bzEY9kyXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    /// if let Some(bonding_curve) = PumpFun::get_creator_vault_pda(&creator) {
+    ///     println!("Creator vault address: {}", creator vault);
+    /// }
+    /// ```
+    pub fn get_creator_vault_pda(creator: &Pubkey) -> Option<Pubkey> {
+        let seeds: &[&[u8]; 2] = &[constants::seeds::CREATOR_VAULT_SEED, creator.as_ref()];
+        let program_id: &Pubkey = &constants::accounts::PUMPFUN;
+        let pda: Option<(Pubkey, u8)> = Pubkey::try_find_program_address(seeds, program_id);
+        pda.map(|pubkey| pubkey.0)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1179,7 +1179,7 @@ impl PumpFun {
     /// #
     /// let creator = pubkey!("Amya8kr2bzEY9kyXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
     /// if let Some(bonding_curve) = PumpFun::get_creator_vault_pda(&creator) {
-    ///     println!("Creator vault address: {}", creator vault);
+    ///     println!("Creator vault address: {}", creator);
     /// }
     /// ```
     pub fn get_creator_vault_pda(creator: &Pubkey) -> Option<Pubkey> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ impl PumpFun {
     /// * `mint` - Keypair for the new token mint account that will be created
     /// * `metadata` - Token metadata including name, symbol, description and image file
     /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
-    ///                    default from the cluster configuration
+    ///   default from the cluster configuration
     ///
     /// # Returns
     ///
@@ -207,9 +207,9 @@ impl PumpFun {
     /// * `metadata` - Token metadata including name, symbol, description and image file
     /// * `amount_sol` - Amount of SOL to spend on the initial buy, in lamports (1 SOL = 1,000,000,000 lamports)
     /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
-    ///                             If None, defaults to 500 (5%)
+    ///   If None, defaults to 500 (5%)
     /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
-    ///                    default from the cluster configuration
+    ///   default from the cluster configuration
     ///
     /// # Returns
     ///
@@ -321,9 +321,9 @@ impl PumpFun {
     /// * `mint` - Public key of the token mint to buy
     /// * `amount_sol` - Amount of SOL to spend, in lamports (1 SOL = 1,000,000,000 lamports)
     /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
-    ///                             If None, defaults to 500 (5%)
+    ///   If None, defaults to 500 (5%)
     /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
-    ///                    default from the cluster configuration
+    ///   default from the cluster configuration
     ///
     /// # Returns
     ///
@@ -416,9 +416,9 @@ impl PumpFun {
     /// * `mint` - Public key of the token mint to sell
     /// * `amount_token` - Optional amount of tokens to sell in base units. If None, sells the entire balance
     /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
-    ///                             If None, defaults to 500 (5%)
+    ///   If None, defaults to 500 (5%)
     /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
-    ///                    default from the cluster configuration
+    ///   default from the cluster configuration
     ///
     /// # Returns
     ///
@@ -513,7 +513,7 @@ impl PumpFun {
     /// # Arguments
     ///
     /// * `commitment` - Optional commitment level for the subscription. If None, uses the
-    ///                  default from the cluster configuration
+    ///   default from the cluster configuration
     /// * `callback` - A function that will be called for each event with the following parameters:
     ///   * `signature`: The transaction signature as a String
     ///   * `event`: The parsed PumpFunEvent if successful, or None if parsing failed
@@ -713,7 +713,7 @@ impl PumpFun {
     /// * `mint` - Public key of the token mint to buy
     /// * `amount_sol` - Amount of SOL to spend, in lamports (1 SOL = 1,000,000,000 lamports)
     /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
-    ///                             If None, defaults to 500 (5%)
+    ///   If None, defaults to 500 (5%)
     ///
     /// # Returns
     ///
@@ -805,7 +805,7 @@ impl PumpFun {
     /// * `mint` - Public key of the token mint to sell
     /// * `amount_token` - Optional amount of tokens to sell in base units. If None, sells the entire balance
     /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
-    ///                             If None, defaults to 500 (5%)
+    ///   If None, defaults to 500 (5%)
     ///
     /// # Returns
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,11 @@ pub mod utils;
 use common::types::{Cluster, PriorityFee};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{
-    compute_budget::ComputeBudgetInstruction,
-    instruction::Instruction,
-    pubkey::Pubkey,
-    signature::{Keypair, Signature},
-    signer::Signer,
+   compute_budget::ComputeBudgetInstruction,
+   instruction::Instruction,
+   pubkey::Pubkey,
+   signature::{Keypair, Signature},
+   signer::Signer,
 };
 use spl_associated_token_account::get_associated_token_address;
 #[cfg(feature = "create-ata")]
@@ -45,1114 +45,1145 @@ use utils::transaction::get_transaction;
 /// let client = PumpFun::new(payer, cluster);
 /// ```
 pub struct PumpFun {
-    /// Keypair used to sign transactions
-    pub payer: Arc<Keypair>,
-    /// RPC client for Solana network requests
-    pub rpc: Arc<RpcClient>,
-    /// Cluster configuration
-    pub cluster: Cluster,
+   /// Keypair used to sign transactions
+   pub payer: Arc<Keypair>,
+   /// RPC client for Solana network requests
+   pub rpc: Arc<RpcClient>,
+   /// Cluster configuration
+   pub cluster: Cluster,
 }
 
 impl PumpFun {
-    /// Creates a new PumpFun client instance
-    ///
-    /// Initializes a new client for interacting with the Pump.fun program on Solana.
-    /// This client manages connection to the Solana network and provides methods for
-    /// creating, buying, and selling tokens.
-    ///
-    /// # Arguments
-    ///
-    /// * `payer` - Keypair used to sign and pay for transactions
-    /// * `cluster` - Solana cluster configuration including RPC endpoints and transaction parameters
-    ///
-    /// # Returns
-    ///
-    /// Returns a new PumpFun client instance configured with the provided parameters
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
-    /// use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
-    /// use std::sync::Arc;
-    ///
-    /// let payer = Arc::new(Keypair::new());
-    /// let commitment = CommitmentConfig::confirmed();
-    /// let priority_fee = PriorityFee::default();
-    /// let cluster = Cluster::devnet(commitment, priority_fee);
-    /// let client = PumpFun::new(payer, cluster);
-    /// ```
-    pub fn new(payer: Arc<Keypair>, cluster: Cluster) -> Self {
-        // Create Solana RPC Client with HTTP endpoint
-        let rpc = Arc::new(RpcClient::new_with_commitment(
-            cluster.rpc.http.clone(),
-            cluster.commitment,
-        ));
+   /// Creates a new PumpFun client instance
+   ///
+   /// Initializes a new client for interacting with the Pump.fun program on Solana.
+   /// This client manages connection to the Solana network and provides methods for
+   /// creating, buying, and selling tokens.
+   ///
+   /// # Arguments
+   ///
+   /// * `payer` - Keypair used to sign and pay for transactions
+   /// * `cluster` - Solana cluster configuration including RPC endpoints and transaction parameters
+   ///
+   /// # Returns
+   ///
+   /// Returns a new PumpFun client instance configured with the provided parameters
+   ///
+   /// # Examples
+   ///
+   /// ```no_run
+   /// use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
+   /// use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
+   /// use std::sync::Arc;
+   ///
+   /// let payer = Arc::new(Keypair::new());
+   /// let commitment = CommitmentConfig::confirmed();
+   /// let priority_fee = PriorityFee::default();
+   /// let cluster = Cluster::devnet(commitment, priority_fee);
+   /// let client = PumpFun::new(payer, cluster);
+   /// ```
+   pub fn new(payer: Arc<Keypair>, cluster: Cluster) -> Self {
+      // Create Solana RPC Client with HTTP endpoint
+      let rpc = Arc::new(RpcClient::new_with_commitment(
+         cluster.rpc.http.clone(),
+         cluster.commitment,
+      ));
 
-        // Return configured PumpFun client
-        Self {
-            payer,
-            rpc,
-            cluster,
-        }
-    }
+      // Return configured PumpFun client
+      Self {
+         payer,
+         rpc,
+         cluster,
+      }
+   }
 
-    /// Creates a new token with metadata by uploading metadata to IPFS and initializing on-chain accounts
-    ///
-    /// This method handles the complete process of creating a new token on Pump.fun:
-    /// 1. Uploads token metadata and image to IPFS
-    /// 2. Creates a new SPL token with the provided mint keypair
-    /// 3. Initializes the bonding curve that determines token pricing
-    /// 4. Sets up metadata using the Metaplex standard
-    ///
-    /// # Arguments
-    ///
-    /// * `mint` - Keypair for the new token mint account that will be created
-    /// * `metadata` - Token metadata including name, symbol, description and image file
-    /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
-    ///                    default from the cluster configuration
-    ///
-    /// # Returns
-    ///
-    /// Returns the transaction signature if successful, or a ClientError if the operation fails
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - Metadata upload to IPFS fails
-    /// - Transaction creation fails
-    /// - Transaction execution on Solana fails
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}, utils::CreateTokenMetadata};
-    /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
-    /// # use std::sync::Arc;
-    /// #
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let payer = Arc::new(Keypair::new());
-    /// # let commitment = CommitmentConfig::confirmed();
-    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-    /// # let client = PumpFun::new(payer, cluster);
-    /// let mint = Keypair::new();
-    /// let metadata = CreateTokenMetadata {
-    ///     name: "My Token".to_string(),
-    ///     symbol: "MYTKN".to_string(),
-    ///     description: "A test token created with Pump.fun".to_string(),
-    ///     file: "path/to/image.png".to_string(),
-    ///     twitter: None,
-    ///     telegram: None,
-    ///     website: Some("https://example.com".to_string()),
-    /// };
-    ///
-    /// let signature = client.create(mint, metadata, None).await?;
-    /// println!("Token created! Signature: {}", signature);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn create(
-        &self,
-        mint: Keypair,
-        metadata: utils::CreateTokenMetadata,
-        priority_fee: Option<PriorityFee>,
-    ) -> Result<Signature, error::ClientError> {
-        // First upload metadata and image to IPFS
-        let ipfs: utils::TokenMetadataResponse = utils::create_token_metadata(metadata)
-            .await
-            .map_err(error::ClientError::UploadMetadataError)?;
+   /// Creates a new token with metadata by uploading metadata to IPFS and initializing on-chain accounts
+   ///
+   /// This method handles the complete process of creating a new token on Pump.fun:
+   /// 1. Uploads token metadata and image to IPFS
+   /// 2. Creates a new SPL token with the provided mint keypair
+   /// 3. Initializes the bonding curve that determines token pricing
+   /// 4. Sets up metadata using the Metaplex standard
+   ///
+   /// # Arguments
+   ///
+   /// * `mint` - Keypair for the new token mint account that will be created
+   /// * `metadata` - Token metadata including name, symbol, description and image file
+   /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
+   ///                    default from the cluster configuration
+   ///
+   /// # Returns
+   ///
+   /// Returns the transaction signature if successful, or a ClientError if the operation fails
+   ///
+   /// # Errors
+   ///
+   /// Returns an error if:
+   /// - Metadata upload to IPFS fails
+   /// - Transaction creation fails
+   /// - Transaction execution on Solana fails
+   ///
+   /// # Examples
+   ///
+   /// ```no_run
+   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}, utils::CreateTokenMetadata};
+   /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
+   /// # use std::sync::Arc;
+   /// #
+   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+   /// # let payer = Arc::new(Keypair::new());
+   /// # let commitment = CommitmentConfig::confirmed();
+   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+   /// # let client = PumpFun::new(payer, cluster);
+   /// let mint = Keypair::new();
+   /// let metadata = CreateTokenMetadata {
+   ///     name: "My Token".to_string(),
+   ///     symbol: "MYTKN".to_string(),
+   ///     description: "A test token created with Pump.fun".to_string(),
+   ///     file: "path/to/image.png".to_string(),
+   ///     twitter: None,
+   ///     telegram: None,
+   ///     website: Some("https://example.com".to_string()),
+   /// };
+   ///
+   /// let signature = client.create(mint, metadata, None).await?;
+   /// println!("Token created! Signature: {}", signature);
+   /// # Ok(())
+   /// # }
+   /// ```
+   pub async fn create(
+      &self,
+      mint: Keypair,
+      metadata: utils::CreateTokenMetadata,
+      priority_fee: Option<PriorityFee>,
+   ) -> Result<Signature, error::ClientError> {
+      // First upload metadata and image to IPFS
+      let ipfs: utils::TokenMetadataResponse = utils::create_token_metadata(metadata)
+         .await
+         .map_err(error::ClientError::UploadMetadataError)?;
 
-        // Add priority fee if provided or default to cluster priority fee
-        let priority_fee = priority_fee.unwrap_or(self.cluster.priority_fee);
-        let mut instructions = Self::get_priority_fee_instructions(&priority_fee);
+      // Add priority fee if provided or default to cluster priority fee
+      let priority_fee = priority_fee.unwrap_or(self.cluster.priority_fee);
+      let mut instructions = Self::get_priority_fee_instructions(&priority_fee);
 
-        // Add create token instruction
-        let create_ix = self.get_create_instruction(&mint, ipfs);
-        instructions.push(create_ix);
+      // Add create token instruction
+      let create_ix = self.get_create_instruction(&mint, ipfs);
+      instructions.push(create_ix);
 
-        // Create and sign transaction
-        let transaction = get_transaction(
-            self.rpc.clone(),
-            self.payer.clone(),
-            &instructions,
-            Some(&[&mint]),
-            #[cfg(feature = "versioned-tx")]
-            None,
-        )
-        .await?;
+      // Create and sign transaction
+      let transaction = get_transaction(
+         self.rpc.clone(),
+         self.payer.clone(),
+         &instructions,
+         Some(&[&mint]),
+         #[cfg(feature = "versioned-tx")]
+         None,
+      )
+      .await?;
 
-        // Send and confirm transaction
-        let signature = self
-            .rpc
-            .send_and_confirm_transaction(&transaction)
-            .await
-            .map_err(error::ClientError::SolanaClientError)?;
+      // Send and confirm transaction
+      let signature = self
+         .rpc
+         .send_and_confirm_transaction(&transaction)
+         .await
+         .map_err(error::ClientError::SolanaClientError)?;
 
-        Ok(signature)
-    }
+      Ok(signature)
+   }
 
-    /// Creates a new token and immediately buys an initial amount in a single atomic transaction
-    ///
-    /// This method combines token creation and an initial purchase into a single atomic transaction.
-    /// This is often preferred for new token launches as it:
-    /// 1. Creates the token and its bonding curve
-    /// 2. Makes an initial purchase to establish liquidity
-    /// 3. Guarantees that the creator becomes the first holder
-    ///
-    /// The entire operation is executed as a single transaction, ensuring atomicity.
-    ///
-    /// # Arguments
-    ///
-    /// * `mint` - Keypair for the new token mint account that will be created
-    /// * `metadata` - Token metadata including name, symbol, description and image file
-    /// * `amount_sol` - Amount of SOL to spend on the initial buy, in lamports (1 SOL = 1,000,000,000 lamports)
-    /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
-    ///                             If None, defaults to 500 (5%)
-    /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
-    ///                    default from the cluster configuration
-    ///
-    /// # Returns
-    ///
-    /// Returns the transaction signature if successful, or a ClientError if the operation fails
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - Metadata upload to IPFS fails
-    /// - Account retrieval fails
-    /// - Transaction creation fails
-    /// - Transaction execution on Solana fails
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}, utils::CreateTokenMetadata};
-    /// # use solana_sdk::{commitment_config::CommitmentConfig, native_token::sol_to_lamports, signature::Keypair};
-    /// # use std::sync::Arc;
-    /// #
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let payer = Arc::new(Keypair::new());
-    /// # let commitment = CommitmentConfig::confirmed();
-    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-    /// # let client = PumpFun::new(payer, cluster);
-    /// let mint = Keypair::new();
-    /// let metadata = CreateTokenMetadata {
-    ///     name: "My Token".to_string(),
-    ///     symbol: "MYTKN".to_string(),
-    ///     description: "A test token created with Pump.fun".to_string(),
-    ///     file: "path/to/image.png".to_string(),
-    ///     twitter: None,
-    ///     telegram: None,
-    ///     website: Some("https://example.com".to_string()),
-    /// };
-    ///
-    /// // Create token and buy 0.1 SOL worth with 5% slippage tolerance
-    /// let amount_sol = sol_to_lamports(0.1f64); // 0.1 SOL in lamports
-    /// let slippage_bps = Some(500); // 5%
-    ///
-    /// let signature = client.create_and_buy(mint, metadata, amount_sol, slippage_bps, None).await?;
-    /// println!("Token created and bought! Signature: {}", signature);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn create_and_buy(
-        &self,
-        mint: Keypair,
-        metadata: utils::CreateTokenMetadata,
-        amount_sol: u64,
-        slippage_basis_points: Option<u64>,
-        priority_fee: Option<PriorityFee>,
-    ) -> Result<Signature, error::ClientError> {
-        // Upload metadata to IPFS first
-        let ipfs: utils::TokenMetadataResponse = utils::create_token_metadata(metadata)
-            .await
-            .map_err(error::ClientError::UploadMetadataError)?;
+   /// Creates a new token and immediately buys an initial amount in a single atomic transaction
+   ///
+   /// This method combines token creation and an initial purchase into a single atomic transaction.
+   /// This is often preferred for new token launches as it:
+   /// 1. Creates the token and its bonding curve
+   /// 2. Makes an initial purchase to establish liquidity
+   /// 3. Guarantees that the creator becomes the first holder
+   ///
+   /// The entire operation is executed as a single transaction, ensuring atomicity.
+   ///
+   /// # Arguments
+   ///
+   /// * `mint` - Keypair for the new token mint account that will be created
+   /// * `metadata` - Token metadata including name, symbol, description and image file
+   /// * `amount_sol` - Amount of SOL to spend on the initial buy, in lamports (1 SOL = 1,000,000,000 lamports)
+   /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
+   ///                             If None, defaults to 500 (5%)
+   /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
+   ///                    default from the cluster configuration
+   ///
+   /// # Returns
+   ///
+   /// Returns the transaction signature if successful, or a ClientError if the operation fails
+   ///
+   /// # Errors
+   ///
+   /// Returns an error if:
+   /// - Metadata upload to IPFS fails
+   /// - Account retrieval fails
+   /// - Transaction creation fails
+   /// - Transaction execution on Solana fails
+   ///
+   /// # Examples
+   ///
+   /// ```no_run
+   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}, utils::CreateTokenMetadata};
+   /// # use solana_sdk::{commitment_config::CommitmentConfig, native_token::sol_to_lamports, signature::Keypair};
+   /// # use std::sync::Arc;
+   /// #
+   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+   /// # let payer = Arc::new(Keypair::new());
+   /// # let commitment = CommitmentConfig::confirmed();
+   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+   /// # let client = PumpFun::new(payer, cluster);
+   /// let mint = Keypair::new();
+   /// let metadata = CreateTokenMetadata {
+   ///     name: "My Token".to_string(),
+   ///     symbol: "MYTKN".to_string(),
+   ///     description: "A test token created with Pump.fun".to_string(),
+   ///     file: "path/to/image.png".to_string(),
+   ///     twitter: None,
+   ///     telegram: None,
+   ///     website: Some("https://example.com".to_string()),
+   /// };
+   ///
+   /// // Create token and buy 0.1 SOL worth with 5% slippage tolerance
+   /// let amount_sol = sol_to_lamports(0.1f64); // 0.1 SOL in lamports
+   /// let slippage_bps = Some(500); // 5%
+   ///
+   /// let signature = client.create_and_buy(mint, metadata, amount_sol, slippage_bps, None).await?;
+   /// println!("Token created and bought! Signature: {}", signature);
+   /// # Ok(())
+   /// # }
+   /// ```
+   pub async fn create_and_buy(
+      &self,
+      mint: Keypair,
+      metadata: utils::CreateTokenMetadata,
+      amount_sol: u64,
+      slippage_basis_points: Option<u64>,
+      priority_fee: Option<PriorityFee>,
+   ) -> Result<Signature, error::ClientError> {
+      // Upload metadata to IPFS first
+      let ipfs: utils::TokenMetadataResponse = utils::create_token_metadata(metadata)
+         .await
+         .map_err(error::ClientError::UploadMetadataError)?;
 
-        // Add priority fee if provided or default to cluster priority fee
-        let priority_fee = priority_fee.unwrap_or(self.cluster.priority_fee);
-        let mut instructions = Self::get_priority_fee_instructions(&priority_fee);
+      // Add priority fee if provided or default to cluster priority fee
+      let priority_fee = priority_fee.unwrap_or(self.cluster.priority_fee);
+      let mut instructions = Self::get_priority_fee_instructions(&priority_fee);
 
-        // Add create token instruction
-        let create_ix = self.get_create_instruction(&mint, ipfs);
-        instructions.push(create_ix);
+      // Add create token instruction
+      let create_ix = self.get_create_instruction(&mint, ipfs);
+      instructions.push(create_ix);
 
-        // Add buy instruction
-        let buy_ix = self
-            .get_buy_instructions(mint.pubkey(), amount_sol, slippage_basis_points)
-            .await?;
-        instructions.extend(buy_ix);
+      // Add buy instruction
+      let buy_ix = self
+         .get_buy_instructions(mint.pubkey(), amount_sol, slippage_basis_points)
+         .await?;
+      instructions.extend(buy_ix);
 
-        // Create and sign transaction
-        let transaction = get_transaction(
-            self.rpc.clone(),
-            self.payer.clone(),
-            &instructions,
-            Some(&[&mint]),
-            #[cfg(feature = "versioned-tx")]
-            None,
-        )
-        .await?;
+      // Create and sign transaction
+      let transaction = get_transaction(
+         self.rpc.clone(),
+         self.payer.clone(),
+         &instructions,
+         Some(&[&mint]),
+         #[cfg(feature = "versioned-tx")]
+         None,
+      )
+      .await?;
 
-        // Send and confirm transaction
-        let signature = self
-            .rpc
-            .send_and_confirm_transaction(&transaction)
-            .await
-            .map_err(error::ClientError::SolanaClientError)?;
+      // Send and confirm transaction
+      let signature = self
+         .rpc
+         .send_and_confirm_transaction(&transaction)
+         .await
+         .map_err(error::ClientError::SolanaClientError)?;
 
-        Ok(signature)
-    }
+      Ok(signature)
+   }
 
-    /// Buys tokens from a bonding curve by spending SOL
-    ///
-    /// This method purchases tokens from a bonding curve by providing SOL. The amount of tokens
-    /// received is determined by the bonding curve formula for the specific token. As more tokens
-    /// are purchased, the price increases according to the curve function.
-    ///
-    /// The method:
-    /// 1. Calculates how many tokens will be received for the given SOL amount
-    /// 2. Creates an associated token account for the buyer if needed
-    /// 3. Executes the buy transaction with slippage protection
-    ///
-    /// A portion of the SOL is taken as a fee according to the global configuration.
-    ///
-    /// # Arguments
-    ///
-    /// * `mint` - Public key of the token mint to buy
-    /// * `amount_sol` - Amount of SOL to spend, in lamports (1 SOL = 1,000,000,000 lamports)
-    /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
-    ///                             If None, defaults to 500 (5%)
-    /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
-    ///                    default from the cluster configuration
-    ///
-    /// # Returns
-    ///
-    /// Returns the transaction signature if successful, or a ClientError if the operation fails
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - The bonding curve account cannot be found
-    /// - The buy price calculation fails
-    /// - Transaction creation fails
-    /// - Transaction execution on Solana fails
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
-    /// # use solana_sdk::{commitment_config::CommitmentConfig, native_token::sol_to_lamports, pubkey, signature::Keypair};
-    /// # use std::sync::Arc;
-    /// #
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let payer = Arc::new(Keypair::new());
-    /// # let commitment = CommitmentConfig::confirmed();
-    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-    /// # let client = PumpFun::new(payer, cluster);
-    /// let token_mint = pubkey!("SoMeTokenM1ntAddr3ssXXXXXXXXXXXXXXXXXXXXXXX");
-    ///
-    /// // Buy 0.01 SOL worth of tokens with 3% max slippage
-    /// let amount_sol = sol_to_lamports(0.01f64); // 0.01 SOL in lamports
-    /// let slippage_bps = Some(300); // 3%
-    ///
-    /// let signature = client.buy(token_mint, amount_sol, slippage_bps, None).await?;
-    /// println!("Tokens purchased! Signature: {}", signature);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn buy(
-        &self,
-        mint: Pubkey,
-        amount_sol: u64,
-        slippage_basis_points: Option<u64>,
-        priority_fee: Option<PriorityFee>,
-    ) -> Result<Signature, error::ClientError> {
-        // Add priority fee if provided or default to cluster priority fee
-        let priority_fee = priority_fee.unwrap_or(self.cluster.priority_fee);
-        let mut instructions = Self::get_priority_fee_instructions(&priority_fee);
+   /// Buys tokens from a bonding curve by spending SOL
+   ///
+   /// This method purchases tokens from a bonding curve by providing SOL. The amount of tokens
+   /// received is determined by the bonding curve formula for the specific token. As more tokens
+   /// are purchased, the price increases according to the curve function.
+   ///
+   /// The method:
+   /// 1. Calculates how many tokens will be received for the given SOL amount
+   /// 2. Creates an associated token account for the buyer if needed
+   /// 3. Executes the buy transaction with slippage protection
+   ///
+   /// A portion of the SOL is taken as a fee according to the global configuration.
+   ///
+   /// # Arguments
+   ///
+   /// * `mint` - Public key of the token mint to buy
+   /// * `amount_sol` - Amount of SOL to spend, in lamports (1 SOL = 1,000,000,000 lamports)
+   /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
+   ///                             If None, defaults to 500 (5%)
+   /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
+   ///                    default from the cluster configuration
+   ///
+   /// # Returns
+   ///
+   /// Returns the transaction signature if successful, or a ClientError if the operation fails
+   ///
+   /// # Errors
+   ///
+   /// Returns an error if:
+   /// - The bonding curve account cannot be found
+   /// - The buy price calculation fails
+   /// - Transaction creation fails
+   /// - Transaction execution on Solana fails
+   ///
+   /// # Examples
+   ///
+   /// ```no_run
+   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
+   /// # use solana_sdk::{commitment_config::CommitmentConfig, native_token::sol_to_lamports, pubkey, signature::Keypair};
+   /// # use std::sync::Arc;
+   /// #
+   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+   /// # let payer = Arc::new(Keypair::new());
+   /// # let commitment = CommitmentConfig::confirmed();
+   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+   /// # let client = PumpFun::new(payer, cluster);
+   /// let token_mint = pubkey!("SoMeTokenM1ntAddr3ssXXXXXXXXXXXXXXXXXXXXXXX");
+   ///
+   /// // Buy 0.01 SOL worth of tokens with 3% max slippage
+   /// let amount_sol = sol_to_lamports(0.01f64); // 0.01 SOL in lamports
+   /// let slippage_bps = Some(300); // 3%
+   ///
+   /// let signature = client.buy(token_mint, amount_sol, slippage_bps, None).await?;
+   /// println!("Tokens purchased! Signature: {}", signature);
+   /// # Ok(())
+   /// # }
+   /// ```
+   pub async fn buy(
+      &self,
+      mint: Pubkey,
+      amount_sol: u64,
+      slippage_basis_points: Option<u64>,
+      priority_fee: Option<PriorityFee>,
+   ) -> Result<Signature, error::ClientError> {
+      // Add priority fee if provided or default to cluster priority fee
+      let priority_fee = priority_fee.unwrap_or(self.cluster.priority_fee);
+      let mut instructions = Self::get_priority_fee_instructions(&priority_fee);
 
-        // Add buy instruction
-        let buy_ix = self
-            .get_buy_instructions(mint, amount_sol, slippage_basis_points)
-            .await?;
-        instructions.extend(buy_ix);
+      // Add buy instruction
+      let buy_ix = self
+         .get_buy_instructions(mint, amount_sol, slippage_basis_points)
+         .await?;
+      instructions.extend(buy_ix);
 
-        // Create and sign transaction
-        let transaction = get_transaction(
-            self.rpc.clone(),
-            self.payer.clone(),
-            &instructions,
-            None,
-            #[cfg(feature = "versioned-tx")]
-            None,
-        )
-        .await?;
+      // Create and sign transaction
+      let transaction = get_transaction(
+         self.rpc.clone(),
+         self.payer.clone(),
+         &instructions,
+         None,
+         #[cfg(feature = "versioned-tx")]
+         None,
+      )
+      .await?;
 
-        // Send and confirm transaction
-        let signature = self
-            .rpc
-            .send_and_confirm_transaction(&transaction)
-            .await
-            .map_err(error::ClientError::SolanaClientError)?;
+      // Send and confirm transaction
+      let signature = self
+         .rpc
+         .send_and_confirm_transaction(&transaction)
+         .await
+         .map_err(error::ClientError::SolanaClientError)?;
 
-        Ok(signature)
-    }
+      Ok(signature)
+   }
 
-    /// Sells tokens back to the bonding curve in exchange for SOL
-    ///
-    /// This method sells tokens back to the bonding curve, receiving SOL in return. The amount of SOL
-    /// received is determined by the bonding curve formula for the specific token. As more tokens
-    /// are sold, the price decreases according to the curve function.
-    ///
-    /// The method:
-    /// 1. Determines how many tokens to sell (all tokens or a specific amount)
-    /// 2. Calculates how much SOL will be received for the tokens
-    /// 3. Executes the sell transaction with slippage protection
-    ///
-    /// A portion of the SOL is taken as a fee according to the global configuration.
-    ///
-    /// # Arguments
-    ///
-    /// * `mint` - Public key of the token mint to sell
-    /// * `amount_token` - Optional amount of tokens to sell in base units. If None, sells the entire balance
-    /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
-    ///                             If None, defaults to 500 (5%)
-    /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
-    ///                    default from the cluster configuration
-    ///
-    /// # Returns
-    ///
-    /// Returns the transaction signature if successful, or a ClientError if the operation fails
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - The token account cannot be found
-    /// - The bonding curve account cannot be found
-    /// - The sell price calculation fails
-    /// - Transaction creation fails
-    /// - Transaction execution on Solana fails
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
-    /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair, pubkey};
-    /// # use std::sync::Arc;
-    /// #
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let payer = Arc::new(Keypair::new());
-    /// # let commitment = CommitmentConfig::confirmed();
-    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-    /// # let client = PumpFun::new(payer, cluster);
-    /// let token_mint = pubkey!("SoMeTokenM1ntAddr3ssXXXXXXXXXXXXXXXXXXXXXXX");
-    ///
-    /// // Sell 1000 tokens with 2% max slippage
-    /// let amount_tokens = Some(1000);
-    /// let slippage_bps = Some(200); // 2%
-    ///
-    /// let signature = client.sell(token_mint, amount_tokens, slippage_bps, None).await?;
-    /// println!("Tokens sold! Signature: {}", signature);
-    ///
-    /// // Or sell all tokens with default slippage (5%)
-    /// let signature = client.sell(token_mint, None, None, None).await?;
-    /// println!("All tokens sold! Signature: {}", signature);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn sell(
-        &self,
-        mint: Pubkey,
-        amount_token: Option<u64>,
-        slippage_basis_points: Option<u64>,
-        priority_fee: Option<PriorityFee>,
-    ) -> Result<Signature, error::ClientError> {
-        // Add priority fee if provided or default to cluster priority fee
-        let priority_fee = priority_fee.unwrap_or(self.cluster.priority_fee);
-        let mut instructions = Self::get_priority_fee_instructions(&priority_fee);
+   /// Sells tokens back to the bonding curve in exchange for SOL
+   ///
+   /// This method sells tokens back to the bonding curve, receiving SOL in return. The amount of SOL
+   /// received is determined by the bonding curve formula for the specific token. As more tokens
+   /// are sold, the price decreases according to the curve function.
+   ///
+   /// The method:
+   /// 1. Determines how many tokens to sell (all tokens or a specific amount)
+   /// 2. Calculates how much SOL will be received for the tokens
+   /// 3. Executes the sell transaction with slippage protection
+   ///
+   /// A portion of the SOL is taken as a fee according to the global configuration.
+   ///
+   /// # Arguments
+   ///
+   /// * `mint` - Public key of the token mint to sell
+   /// * `amount_token` - Optional amount of tokens to sell in base units. If None, sells the entire balance
+   /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
+   ///                             If None, defaults to 500 (5%)
+   /// * `priority_fee` - Optional priority fee configuration for compute units. If None, uses the
+   ///                    default from the cluster configuration
+   ///
+   /// # Returns
+   ///
+   /// Returns the transaction signature if successful, or a ClientError if the operation fails
+   ///
+   /// # Errors
+   ///
+   /// Returns an error if:
+   /// - The token account cannot be found
+   /// - The bonding curve account cannot be found
+   /// - The sell price calculation fails
+   /// - Transaction creation fails
+   /// - Transaction execution on Solana fails
+   ///
+   /// # Examples
+   ///
+   /// ```no_run
+   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
+   /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair, pubkey};
+   /// # use std::sync::Arc;
+   /// #
+   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+   /// # let payer = Arc::new(Keypair::new());
+   /// # let commitment = CommitmentConfig::confirmed();
+   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+   /// # let client = PumpFun::new(payer, cluster);
+   /// let token_mint = pubkey!("SoMeTokenM1ntAddr3ssXXXXXXXXXXXXXXXXXXXXXXX");
+   ///
+   /// // Sell 1000 tokens with 2% max slippage
+   /// let amount_tokens = Some(1000);
+   /// let slippage_bps = Some(200); // 2%
+   ///
+   /// let signature = client.sell(token_mint, amount_tokens, slippage_bps, None).await?;
+   /// println!("Tokens sold! Signature: {}", signature);
+   ///
+   /// // Or sell all tokens with default slippage (5%)
+   /// let signature = client.sell(token_mint, None, None, None).await?;
+   /// println!("All tokens sold! Signature: {}", signature);
+   /// # Ok(())
+   /// # }
+   /// ```
+   pub async fn sell(
+      &self,
+      mint: Pubkey,
+      amount_token: Option<u64>,
+      slippage_basis_points: Option<u64>,
+      priority_fee: Option<PriorityFee>,
+   ) -> Result<Signature, error::ClientError> {
+      // Add priority fee if provided or default to cluster priority fee
+      let priority_fee = priority_fee.unwrap_or(self.cluster.priority_fee);
+      let mut instructions = Self::get_priority_fee_instructions(&priority_fee);
 
-        // Add sell instruction
-        let sell_ix = self
-            .get_sell_instructions(mint, amount_token, slippage_basis_points)
-            .await?;
-        instructions.extend(sell_ix);
+      // Add sell instruction
+      let sell_ix = self
+         .get_sell_instructions(mint, amount_token, slippage_basis_points)
+         .await?;
+      instructions.extend(sell_ix);
 
-        // Create and sign transaction
-        let transaction = get_transaction(
-            self.rpc.clone(),
-            self.payer.clone(),
-            &instructions,
-            None,
-            #[cfg(feature = "versioned-tx")]
-            None,
-        )
-        .await?;
+      // Create and sign transaction
+      let transaction = get_transaction(
+         self.rpc.clone(),
+         self.payer.clone(),
+         &instructions,
+         None,
+         #[cfg(feature = "versioned-tx")]
+         None,
+      )
+      .await?;
 
-        // Send and confirm transaction
-        let signature = self
-            .rpc
-            .send_and_confirm_transaction(&transaction)
-            .await
-            .map_err(error::ClientError::SolanaClientError)?;
+      // Send and confirm transaction
+      let signature = self
+         .rpc
+         .send_and_confirm_transaction(&transaction)
+         .await
+         .map_err(error::ClientError::SolanaClientError)?;
 
-        Ok(signature)
-    }
+      Ok(signature)
+   }
 
-    /// Subscribes to real-time events from the Pump.fun program
-    ///
-    /// This method establishes a WebSocket connection to the Solana cluster and subscribes
-    /// to program log events from the Pump.fun program. It parses the emitted events into
-    /// structured data types and delivers them through the provided callback function.
-    ///
-    /// Event types include:
-    /// - `CreateEvent`: Emitted when a new token is created
-    /// - `TradeEvent`: Emitted when tokens are bought or sold
-    /// - `CompleteEvent`: Emitted when a bonding curve operation completes
-    /// - `SetParamsEvent`: Emitted when global parameters are updated
-    ///
-    /// # Arguments
-    ///
-    /// * `commitment` - Optional commitment level for the subscription. If None, uses the
-    ///                  default from the cluster configuration
-    /// * `callback` - A function that will be called for each event with the following parameters:
-    ///   * `signature`: The transaction signature as a String
-    ///   * `event`: The parsed PumpFunEvent if successful, or None if parsing failed
-    ///   * `error`: Any error that occurred during parsing, or None if successful
-    ///   * `response`: The complete RPC logs response for additional context
-    ///
-    /// # Returns
-    ///
-    /// Returns a `Subscription` object that manages the lifecycle of the subscription.
-    /// When this object is dropped, the subscription is automatically terminated. If
-    /// the subscription cannot be established, returns a ClientError.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - The WebSocket connection cannot be established
-    /// - The subscription request fails
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
-    /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
-    /// # use std::{sync::Arc, error::Error};
-    /// #
-    /// # async fn example() -> Result<(), Box<dyn Error>> {
-    /// # let payer = Arc::new(Keypair::new());
-    /// # let commitment = CommitmentConfig::confirmed();
-    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-    /// # let client = PumpFun::new(payer, cluster);
-    /// #
-    /// // Subscribe to token events
-    /// let subscription = client.subscribe(None, |signature, event, error, _| {
-    ///     match event {
-    ///         Some(pumpfun::common::stream::PumpFunEvent::Create(create_event)) => {
-    ///             println!("New token created: {} ({})", create_event.name, create_event.symbol);
-    ///             println!("Mint address: {}", create_event.mint);
-    ///         },
-    ///         Some(pumpfun::common::stream::PumpFunEvent::Trade(trade_event)) => {
-    ///             let action = if trade_event.is_buy { "bought" } else { "sold" };
-    ///             println!(
-    ///                 "User {} {} {} tokens for {} SOL",
-    ///                 trade_event.user,
-    ///                 action,
-    ///                 trade_event.token_amount,
-    ///                 trade_event.sol_amount as f64 / 1_000_000_000.0
-    ///             );
-    ///         },
-    ///         Some(event) => println!("Other event received: {:#?}", event),
-    ///         None => {
-    ///             if let Some(err) = error {
-    ///                 eprintln!("Error parsing event in tx {}: {}", signature, err);
-    ///             }
-    ///         }
-    ///     }
-    /// }).await?;
-    ///
-    /// // Keep the subscription active
-    /// // When no longer needed, drop the subscription to unsubscribe
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[cfg(feature = "stream")]
-    pub async fn subscribe<F>(
-        &self,
-        commitment: Option<solana_sdk::commitment_config::CommitmentConfig>,
-        callback: F,
-    ) -> Result<common::stream::Subscription, error::ClientError>
-    where
-        F: Fn(
-                String,
-                Option<common::stream::PumpFunEvent>,
-                Option<Box<dyn std::error::Error>>,
-                solana_client::rpc_response::Response<solana_client::rpc_response::RpcLogsResponse>,
-            ) + Send
-            + Sync
-            + 'static,
-    {
-        common::stream::subscribe(self.cluster.clone(), commitment, callback).await
-    }
+   /// Subscribes to real-time events from the Pump.fun program
+   ///
+   /// This method establishes a WebSocket connection to the Solana cluster and subscribes
+   /// to program log events from the Pump.fun program. It parses the emitted events into
+   /// structured data types and delivers them through the provided callback function.
+   ///
+   /// Event types include:
+   /// - `CreateEvent`: Emitted when a new token is created
+   /// - `TradeEvent`: Emitted when tokens are bought or sold
+   /// - `CompleteEvent`: Emitted when a bonding curve operation completes
+   /// - `SetParamsEvent`: Emitted when global parameters are updated
+   ///
+   /// # Arguments
+   ///
+   /// * `commitment` - Optional commitment level for the subscription. If None, uses the
+   ///                  default from the cluster configuration
+   /// * `callback` - A function that will be called for each event with the following parameters:
+   ///   * `signature`: The transaction signature as a String
+   ///   * `event`: The parsed PumpFunEvent if successful, or None if parsing failed
+   ///   * `error`: Any error that occurred during parsing, or None if successful
+   ///   * `response`: The complete RPC logs response for additional context
+   ///
+   /// # Returns
+   ///
+   /// Returns a `Subscription` object that manages the lifecycle of the subscription.
+   /// When this object is dropped, the subscription is automatically terminated. If
+   /// the subscription cannot be established, returns a ClientError.
+   ///
+   /// # Errors
+   ///
+   /// Returns an error if:
+   /// - The WebSocket connection cannot be established
+   /// - The subscription request fails
+   ///
+   /// # Examples
+   ///
+   /// ```no_run
+   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
+   /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
+   /// # use std::{sync::Arc, error::Error};
+   /// #
+   /// # async fn example() -> Result<(), Box<dyn Error>> {
+   /// # let payer = Arc::new(Keypair::new());
+   /// # let commitment = CommitmentConfig::confirmed();
+   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+   /// # let client = PumpFun::new(payer, cluster);
+   /// #
+   /// // Subscribe to token events
+   /// let subscription = client.subscribe(None, |signature, event, error, _| {
+   ///     match event {
+   ///         Some(pumpfun::common::stream::PumpFunEvent::Create(create_event)) => {
+   ///             println!("New token created: {} ({})", create_event.name, create_event.symbol);
+   ///             println!("Mint address: {}", create_event.mint);
+   ///         },
+   ///         Some(pumpfun::common::stream::PumpFunEvent::Trade(trade_event)) => {
+   ///             let action = if trade_event.is_buy { "bought" } else { "sold" };
+   ///             println!(
+   ///                 "User {} {} {} tokens for {} SOL",
+   ///                 trade_event.user,
+   ///                 action,
+   ///                 trade_event.token_amount,
+   ///                 trade_event.sol_amount as f64 / 1_000_000_000.0
+   ///             );
+   ///         },
+   ///         Some(event) => println!("Other event received: {:#?}", event),
+   ///         None => {
+   ///             if let Some(err) = error {
+   ///                 eprintln!("Error parsing event in tx {}: {}", signature, err);
+   ///             }
+   ///         }
+   ///     }
+   /// }).await?;
+   ///
+   /// // Keep the subscription active
+   /// // When no longer needed, drop the subscription to unsubscribe
+   /// # Ok(())
+   /// # }
+   /// ```
+   #[cfg(feature = "stream")]
+   pub async fn subscribe<F>(
+      &self,
+      commitment: Option<solana_sdk::commitment_config::CommitmentConfig>,
+      callback: F,
+   ) -> Result<common::stream::Subscription, error::ClientError>
+   where
+      F: Fn(
+            String,
+            Option<common::stream::PumpFunEvent>,
+            Option<Box<dyn std::error::Error>>,
+            solana_client::rpc_response::Response<solana_client::rpc_response::RpcLogsResponse>,
+         ) + Send
+         + Sync
+         + 'static,
+   {
+      common::stream::subscribe(self.cluster.clone(), commitment, callback).await
+   }
 
-    /// Creates compute budget instructions for priority fees
-    ///
-    /// Generates Solana compute budget instructions based on the provided priority fee
-    /// configuration. These instructions are used to set the maximum compute units a
-    /// transaction can consume and the price per compute unit, which helps prioritize
-    /// transaction processing during network congestion.
-    ///
-    /// # Arguments
-    ///
-    /// * `priority_fee` - Priority fee configuration containing optional unit limit and unit price
-    ///
-    /// # Returns
-    ///
-    /// Returns a vector of instructions to set compute budget parameters, which can be
-    /// empty if no priority fee parameters are provided
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use pumpfun::{PumpFun, common::types::PriorityFee};
-    /// # use solana_sdk::instruction::Instruction;
-    /// #
-    /// // Set both compute unit limit and price
-    /// let priority_fee = PriorityFee {
-    ///     unit_limit: Some(200_000),
-    ///     unit_price: Some(1_000), // 1000 micro-lamports per compute unit
-    /// };
-    ///
-    /// let compute_instructions: Vec<Instruction> = PumpFun::get_priority_fee_instructions(&priority_fee);
-    /// ```
-    pub fn get_priority_fee_instructions(priority_fee: &PriorityFee) -> Vec<Instruction> {
-        let mut instructions = Vec::new();
+   /// Creates compute budget instructions for priority fees
+   ///
+   /// Generates Solana compute budget instructions based on the provided priority fee
+   /// configuration. These instructions are used to set the maximum compute units a
+   /// transaction can consume and the price per compute unit, which helps prioritize
+   /// transaction processing during network congestion.
+   ///
+   /// # Arguments
+   ///
+   /// * `priority_fee` - Priority fee configuration containing optional unit limit and unit price
+   ///
+   /// # Returns
+   ///
+   /// Returns a vector of instructions to set compute budget parameters, which can be
+   /// empty if no priority fee parameters are provided
+   ///
+   /// # Examples
+   ///
+   /// ```no_run
+   /// # use pumpfun::{PumpFun, common::types::PriorityFee};
+   /// # use solana_sdk::instruction::Instruction;
+   /// #
+   /// // Set both compute unit limit and price
+   /// let priority_fee = PriorityFee {
+   ///     unit_limit: Some(200_000),
+   ///     unit_price: Some(1_000), // 1000 micro-lamports per compute unit
+   /// };
+   ///
+   /// let compute_instructions: Vec<Instruction> = PumpFun::get_priority_fee_instructions(&priority_fee);
+   /// ```
+   pub fn get_priority_fee_instructions(priority_fee: &PriorityFee) -> Vec<Instruction> {
+      let mut instructions = Vec::new();
 
-        if let Some(limit) = priority_fee.unit_limit {
-            let limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(limit);
-            instructions.push(limit_ix);
-        }
+      if let Some(limit) = priority_fee.unit_limit {
+         let limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(limit);
+         instructions.push(limit_ix);
+      }
 
-        if let Some(price) = priority_fee.unit_price {
-            let price_ix = ComputeBudgetInstruction::set_compute_unit_price(price);
-            instructions.push(price_ix);
-        }
+      if let Some(price) = priority_fee.unit_price {
+         let price_ix = ComputeBudgetInstruction::set_compute_unit_price(price);
+         instructions.push(price_ix);
+      }
 
-        instructions
-    }
+      instructions
+   }
 
-    /// Creates an instruction for initializing a new token
-    ///
-    /// Generates a Solana instruction to create a new token with a bonding curve on Pump.fun.
-    /// This instruction will initialize the token mint, metadata, and bonding curve accounts.
-    ///
-    /// # Arguments
-    ///
-    /// * `mint` - Keypair for the new token mint account that will be created
-    /// * `ipfs` - Token metadata response from IPFS upload containing name, symbol, and URI
-    ///
-    /// # Returns
-    ///
-    /// Returns a Solana instruction for creating a new token
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}, utils};
-    /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
-    /// # use std::sync::Arc;
-    /// #
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let payer = Arc::new(Keypair::new());
-    /// # let commitment = CommitmentConfig::confirmed();
-    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-    /// # let client = PumpFun::new(payer, cluster);
-    /// #
-    /// let mint = Keypair::new();
-    /// let metadata_response = utils::create_token_metadata(
-    ///     utils::CreateTokenMetadata {
-    ///         name: "Example Token".to_string(),
-    ///         symbol: "EXTKN".to_string(),
-    ///         description: "An example token".to_string(),
-    ///         file: "path/to/image.png".to_string(),
-    ///         twitter: None,
-    ///         telegram: None,
-    ///         website: None,
-    ///     }
-    /// ).await?;
-    ///
-    /// let create_instruction = client.get_create_instruction(&mint, metadata_response);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn get_create_instruction(
-        &self,
-        mint: &Keypair,
-        ipfs: utils::TokenMetadataResponse,
-    ) -> Instruction {
-        instructions::create(
-            &self.payer,
-            mint,
-            instructions::Create {
-                name: ipfs.metadata.name,
-                symbol: ipfs.metadata.symbol,
-                uri: ipfs.metadata.image,
-                creator: self.payer.pubkey(),
-            },
-        )
-    }
+   /// Creates an instruction for initializing a new token
+   ///
+   /// Generates a Solana instruction to create a new token with a bonding curve on Pump.fun.
+   /// This instruction will initialize the token mint, metadata, and bonding curve accounts.
+   ///
+   /// # Arguments
+   ///
+   /// * `mint` - Keypair for the new token mint account that will be created
+   /// * `ipfs` - Token metadata response from IPFS upload containing name, symbol, and URI
+   ///
+   /// # Returns
+   ///
+   /// Returns a Solana instruction for creating a new token
+   ///
+   /// # Examples
+   ///
+   /// ```no_run
+   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}, utils};
+   /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
+   /// # use std::sync::Arc;
+   /// #
+   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+   /// # let payer = Arc::new(Keypair::new());
+   /// # let commitment = CommitmentConfig::confirmed();
+   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+   /// # let client = PumpFun::new(payer, cluster);
+   /// #
+   /// let mint = Keypair::new();
+   /// let metadata_response = utils::create_token_metadata(
+   ///     utils::CreateTokenMetadata {
+   ///         name: "Example Token".to_string(),
+   ///         symbol: "EXTKN".to_string(),
+   ///         description: "An example token".to_string(),
+   ///         file: "path/to/image.png".to_string(),
+   ///         twitter: None,
+   ///         telegram: None,
+   ///         website: None,
+   ///     }
+   /// ).await?;
+   ///
+   /// let create_instruction = client.get_create_instruction(&mint, metadata_response);
+   /// # Ok(())
+   /// # }
+   /// ```
+   pub fn get_create_instruction(
+      &self,
+      mint: &Keypair,
+      ipfs: utils::TokenMetadataResponse,
+   ) -> Instruction {
+      instructions::create(
+         &self.payer,
+         mint,
+         instructions::Create {
+            name: ipfs.metadata.name,
+            symbol: ipfs.metadata.symbol,
+            uri: ipfs.metadata.image,
+            creator: self.payer.pubkey(),
+         },
+      )
+   }
 
-    /// Generates instructions for buying tokens from a bonding curve
-    ///
-    /// Creates a set of Solana instructions needed to purchase tokens using SOL. These
-    /// instructions may include creating an associated token account if needed, and the actual
-    /// buy instruction with slippage protection.
-    ///
-    /// # Arguments
-    ///
-    /// * `mint` - Public key of the token mint to buy
-    /// * `amount_sol` - Amount of SOL to spend, in lamports (1 SOL = 1,000,000,000 lamports)
-    /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
-    ///                             If None, defaults to 500 (5%)
-    ///
-    /// # Returns
-    ///
-    /// Returns a vector of Solana instructions if successful, or a ClientError if the operation fails
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - The global account or bonding curve account cannot be fetched
-    /// - The buy price calculation fails
-    /// - Token account-related operations fail
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
-    /// # use solana_sdk::{commitment_config::CommitmentConfig, native_token::sol_to_lamports, signature::Keypair, pubkey};
-    /// # use std::sync::Arc;
-    /// #
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let payer = Arc::new(Keypair::new());
-    /// # let commitment = CommitmentConfig::confirmed();
-    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-    /// # let client = PumpFun::new(payer, cluster);
-    /// #
-    /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
-    /// let amount_sol = sol_to_lamports(0.01); // 0.01 SOL
-    /// let slippage_bps = Some(300); // 3%
-    ///
-    /// let buy_instructions = client.get_buy_instructions(mint, amount_sol, slippage_bps).await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn get_buy_instructions(
-        &self,
-        mint: Pubkey,
-        amount_sol: u64,
-        slippage_basis_points: Option<u64>,
-    ) -> Result<Vec<Instruction>, error::ClientError> {
-        // Get accounts and calculate buy amounts
-        let global_account = self.get_global_account().await?;
-        let bonding_curve_account = self.get_bonding_curve_account(&mint).await?;
-        let buy_amount = bonding_curve_account
-            .get_buy_price(amount_sol)
-            .map_err(error::ClientError::BondingCurveError)?;
-        let buy_amount_with_slippage =
-            utils::calculate_with_slippage_buy(amount_sol, slippage_basis_points.unwrap_or(500));
+   /// Generates instructions for buying tokens from a bonding curve
+   ///
+   /// Creates a set of Solana instructions needed to purchase tokens using SOL. These
+   /// instructions may include creating an associated token account if needed, and the actual
+   /// buy instruction with slippage protection.
+   ///
+   /// # Arguments
+   ///
+   /// * `mint` - Public key of the token mint to buy
+   /// * `amount_sol` - Amount of SOL to spend, in lamports (1 SOL = 1,000,000,000 lamports)
+   /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
+   ///                             If None, defaults to 500 (5%)
+   ///
+   /// # Returns
+   ///
+   /// Returns a vector of Solana instructions if successful, or a ClientError if the operation fails
+   ///
+   /// # Errors
+   ///
+   /// Returns an error if:
+   /// - The global account or bonding curve account cannot be fetched
+   /// - The buy price calculation fails
+   /// - Token account-related operations fail
+   ///
+   /// # Examples
+   ///
+   /// ```no_run
+   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
+   /// # use solana_sdk::{commitment_config::CommitmentConfig, native_token::sol_to_lamports, signature::Keypair, pubkey};
+   /// # use std::sync::Arc;
+   /// #
+   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+   /// # let payer = Arc::new(Keypair::new());
+   /// # let commitment = CommitmentConfig::confirmed();
+   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+   /// # let client = PumpFun::new(payer, cluster);
+   /// #
+   /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+   /// let amount_sol = sol_to_lamports(0.01); // 0.01 SOL
+   /// let slippage_bps = Some(300); // 3%
+   ///
+   /// let buy_instructions = client.get_buy_instructions(mint, amount_sol, slippage_bps).await?;
+   /// # Ok(())
+   /// # }
+   /// ```
+   pub async fn get_buy_instructions(
+      &self,
+      mint: Pubkey,
+      amount_sol: u64,
+      slippage_basis_points: Option<u64>,
+   ) -> Result<Vec<Instruction>, error::ClientError> {
+      // Get accounts and calculate buy amounts
+      let global_account = self.get_global_account().await?;
+      let bonding_curve_account = self.get_bonding_curve_account(&mint).await?;
+      let buy_amount = bonding_curve_account
+         .get_buy_price(amount_sol)
+         .map_err(error::ClientError::BondingCurveError)?;
+      let buy_amount_with_slippage =
+         utils::calculate_with_slippage_buy(amount_sol, slippage_basis_points.unwrap_or(500));
 
-        let mut instructions = Vec::new();
+      let mut instructions = Vec::new();
 
-        // Create Associated Token Account if needed
-        #[cfg(feature = "create-ata")]
-        {
-            let ata: Pubkey = get_associated_token_address(&self.payer.pubkey(), &mint);
-            if self.rpc.get_account(&ata).await.is_err() {
-                instructions.push(create_associated_token_account(
-                    &self.payer.pubkey(),
-                    &self.payer.pubkey(),
-                    &mint,
-                    &constants::accounts::TOKEN_PROGRAM,
-                ));
-            }
-        }
+      // Create Associated Token Account if needed
+      #[cfg(feature = "create-ata")]
+      {
+         let ata: Pubkey = get_associated_token_address(&self.payer.pubkey(), &mint);
+         if self.rpc.get_account(&ata).await.is_err() {
+            instructions.push(create_associated_token_account(
+               &self.payer.pubkey(),
+               &self.payer.pubkey(),
+               &mint,
+               &constants::accounts::TOKEN_PROGRAM,
+            ));
+         }
+      }
 
-        // Add buy instruction
-        instructions.push(instructions::buy(
-            &self.payer,
-            &mint,
-            &global_account.fee_recipient,
-            instructions::Buy {
-                amount: buy_amount,
-                max_sol_cost: buy_amount_with_slippage,
-            },
-        ));
+      // Add buy instruction
+      instructions.push(instructions::buy(
+         &self.payer,
+         &mint,
+         &global_account.fee_recipient,
+         &bonding_curve_account.creator,
+         instructions::Buy {
+            amount: buy_amount,
+            max_sol_cost: buy_amount_with_slippage,
+         },
+      ));
 
-        Ok(instructions)
-    }
+      Ok(instructions)
+   }
 
-    /// Generates instructions for selling tokens back to a bonding curve
-    ///
-    /// Creates a set of Solana instructions needed to sell tokens in exchange for SOL. These
-    /// instructions include the sell instruction with slippage protection and may include
-    /// closing the associated token account if all tokens are being sold and the feature
-    /// is enabled.
-    ///
-    /// # Arguments
-    ///
-    /// * `mint` - Public key of the token mint to sell
-    /// * `amount_token` - Optional amount of tokens to sell in base units. If None, sells the entire balance
-    /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
-    ///                             If None, defaults to 500 (5%)
-    ///
-    /// # Returns
-    ///
-    /// Returns a vector of Solana instructions if successful, or a ClientError if the operation fails
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - The token account or token balance cannot be fetched
-    /// - The global account or bonding curve account cannot be fetched
-    /// - The sell price calculation fails
-    /// - Token account closing operations fail (when applicable)
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
-    /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair, pubkey};
-    /// # use std::sync::Arc;
-    /// #
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let payer = Arc::new(Keypair::new());
-    /// # let commitment = CommitmentConfig::confirmed();
-    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-    /// # let client = PumpFun::new(payer, cluster);
-    /// #
-    /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
-    /// let amount_tokens = Some(1000); // Sell 1000 tokens
-    /// let slippage_bps = Some(200); // 2%
-    ///
-    /// let sell_instructions = client.get_sell_instructions(mint, amount_tokens, slippage_bps).await?;
-    ///
-    /// // Or to sell all tokens:
-    /// let sell_all_instructions = client.get_sell_instructions(mint, None, None).await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn get_sell_instructions(
-        &self,
-        mint: Pubkey,
-        amount_token: Option<u64>,
-        slippage_basis_points: Option<u64>,
-    ) -> Result<Vec<Instruction>, error::ClientError> {
-        // Get ATA
-        let ata: Pubkey = get_associated_token_address(&self.payer.pubkey(), &mint);
+   /// Generates instructions for selling tokens back to a bonding curve
+   ///
+   /// Creates a set of Solana instructions needed to sell tokens in exchange for SOL. These
+   /// instructions include the sell instruction with slippage protection and may include
+   /// closing the associated token account if all tokens are being sold and the feature
+   /// is enabled.
+   ///
+   /// # Arguments
+   ///
+   /// * `mint` - Public key of the token mint to sell
+   /// * `amount_token` - Optional amount of tokens to sell in base units. If None, sells the entire balance
+   /// * `slippage_basis_points` - Optional maximum acceptable slippage in basis points (1 bp = 0.01%).
+   ///                             If None, defaults to 500 (5%)
+   ///
+   /// # Returns
+   ///
+   /// Returns a vector of Solana instructions if successful, or a ClientError if the operation fails
+   ///
+   /// # Errors
+   ///
+   /// Returns an error if:
+   /// - The token account or token balance cannot be fetched
+   /// - The global account or bonding curve account cannot be fetched
+   /// - The sell price calculation fails
+   /// - Token account closing operations fail (when applicable)
+   ///
+   /// # Examples
+   ///
+   /// ```no_run
+   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
+   /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair, pubkey};
+   /// # use std::sync::Arc;
+   /// #
+   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+   /// # let payer = Arc::new(Keypair::new());
+   /// # let commitment = CommitmentConfig::confirmed();
+   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+   /// # let client = PumpFun::new(payer, cluster);
+   /// #
+   /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+   /// let amount_tokens = Some(1000); // Sell 1000 tokens
+   /// let slippage_bps = Some(200); // 2%
+   ///
+   /// let sell_instructions = client.get_sell_instructions(mint, amount_tokens, slippage_bps).await?;
+   ///
+   /// // Or to sell all tokens:
+   /// let sell_all_instructions = client.get_sell_instructions(mint, None, None).await?;
+   /// # Ok(())
+   /// # }
+   /// ```
+   pub async fn get_sell_instructions(
+      &self,
+      mint: Pubkey,
+      amount_token: Option<u64>,
+      slippage_basis_points: Option<u64>,
+   ) -> Result<Vec<Instruction>, error::ClientError> {
+      // Get ATA
+      let ata: Pubkey = get_associated_token_address(&self.payer.pubkey(), &mint);
 
-        // Get token balance
-        let token_balance = if amount_token.is_none() || cfg!(feature = "close-ata") {
-            // We need the balance if amount_token is None OR if the close-ata feature is enabled
-            let balance = self.rpc.get_token_account_balance(&ata).await?;
-            Some(balance.amount.parse::<u64>().unwrap())
-        } else {
-            None
-        };
+      // Get token balance
+      let token_balance = if amount_token.is_none() || cfg!(feature = "close-ata") {
+         // We need the balance if amount_token is None OR if the close-ata feature is enabled
+         let balance = self.rpc.get_token_account_balance(&ata).await?;
+         Some(balance.amount.parse::<u64>().unwrap())
+      } else {
+         None
+      };
 
-        // Determine amount to sell
-        let amount = amount_token.unwrap_or_else(|| token_balance.unwrap());
+      // Determine amount to sell
+      let amount = amount_token.unwrap_or_else(|| token_balance.unwrap());
 
-        // Calculate min sol output
-        let global_account = self.get_global_account().await?;
-        let bonding_curve_account = self.get_bonding_curve_account(&mint).await?;
-        let min_sol_output = bonding_curve_account
-            .get_sell_price(amount, global_account.fee_basis_points)
-            .map_err(error::ClientError::BondingCurveError)?;
-        let min_sol_output = utils::calculate_with_slippage_sell(
+      // Calculate min sol output
+      let global_account = self.get_global_account().await?;
+      let bonding_curve_account = self.get_bonding_curve_account(&mint).await?;
+      let min_sol_output = bonding_curve_account
+         .get_sell_price(amount, global_account.fee_basis_points)
+         .map_err(error::ClientError::BondingCurveError)?;
+      let min_sol_output =
+         utils::calculate_with_slippage_sell(min_sol_output, slippage_basis_points.unwrap_or(500));
+
+      let mut instructions = Vec::new();
+
+      // Add sell instruction
+      instructions.push(instructions::sell(
+         &self.payer,
+         &mint,
+         &global_account.fee_recipient,
+         &bonding_curve_account.creator,
+         instructions::Sell {
+            amount,
             min_sol_output,
-            slippage_basis_points.unwrap_or(500),
-        );
+         },
+      ));
 
-        let mut instructions = Vec::new();
+      // Close account if balance equals amount
+      #[cfg(feature = "close-ata")]
+      {
+         // Token balance should be guaranteed to be available at this point
+         // due to our fetch logic in the beginning of the function
+         if let Some(balance) = token_balance {
+            // Only close the account if we're selling all tokens
+            if balance == amount {
+               let token_program = constants::accounts::TOKEN_PROGRAM;
 
-        // Add sell instruction
-        instructions.push(instructions::sell(
-            &self.payer,
-            &mint,
-            &global_account.fee_recipient,
-            instructions::Sell {
-                amount,
-                min_sol_output,
-            },
-        ));
+               // Verify the token account exists before attempting to close it
+               if self.rpc.get_account(&ata).await.is_ok() {
+                  // Create instruction to close the ATA
+                  let close_instruction = close_account(
+                     &token_program,
+                     &ata,
+                     &self.payer.pubkey(),
+                     &self.payer.pubkey(),
+                     &[&self.payer.pubkey()],
+                  )
+                  .map_err(|err| {
+                     error::ClientError::OtherError(format!(
+                        "Failed to create close account instruction: pubkey={}: {}",
+                        ata, err
+                     ))
+                  })?;
 
-        // Close account if balance equals amount
-        #[cfg(feature = "close-ata")]
-        {
-            // Token balance should be guaranteed to be available at this point
-            // due to our fetch logic in the beginning of the function
-            if let Some(balance) = token_balance {
-                // Only close the account if we're selling all tokens
-                if balance == amount {
-                    let token_program = constants::accounts::TOKEN_PROGRAM;
-
-                    // Verify the token account exists before attempting to close it
-                    if self.rpc.get_account(&ata).await.is_ok() {
-                        // Create instruction to close the ATA
-                        let close_instruction = close_account(
-                            &token_program,
-                            &ata,
-                            &self.payer.pubkey(),
-                            &self.payer.pubkey(),
-                            &[&self.payer.pubkey()],
-                        )
-                        .map_err(|err| {
-                            error::ClientError::OtherError(format!(
-                                "Failed to create close account instruction: pubkey={}: {}",
-                                ata, err
-                            ))
-                        })?;
-
-                        instructions.push(close_instruction);
-                    } else {
-                        // Log warning but don't fail the transaction if account doesn't exist
-                        eprintln!(
-                            "Warning: Cannot close token account {}, it doesn't exist",
-                            ata
-                        );
-                    }
-                }
-            } else {
-                // This case should not occur due to our balance fetch logic,
-                // but handle it gracefully just in case
-                eprintln!("Warning: Token balance unavailable, not closing account");
+                  instructions.push(close_instruction);
+               } else {
+                  // Log warning but don't fail the transaction if account doesn't exist
+                  eprintln!(
+                     "Warning: Cannot close token account {}, it doesn't exist",
+                     ata
+                  );
+               }
             }
-        }
+         } else {
+            // This case should not occur due to our balance fetch logic,
+            // but handle it gracefully just in case
+            eprintln!("Warning: Token balance unavailable, not closing account");
+         }
+      }
 
-        Ok(instructions)
-    }
+      Ok(instructions)
+   }
 
-    /// Gets the Program Derived Address (PDA) for the global state account
-    ///
-    /// Derives the address of the global state account using the program ID and a
-    /// constant seed. The global state account contains program-wide configuration
-    /// such as fee settings and fee recipient.
-    ///
-    /// # Returns
-    ///
-    /// Returns the PDA public key derived from the GLOBAL_SEED
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use pumpfun::PumpFun;
-    /// # use solana_sdk::pubkey::Pubkey;
-    /// #
-    /// let global_pda: Pubkey = PumpFun::get_global_pda();
-    /// println!("Global state account: {}", global_pda);
-    /// ```
-    pub fn get_global_pda() -> Pubkey {
-        let seeds: &[&[u8]; 1] = &[constants::seeds::GLOBAL_SEED];
-        let program_id: &Pubkey = &constants::accounts::PUMPFUN;
-        Pubkey::find_program_address(seeds, program_id).0
-    }
+   /// Gets the Program Derived Address (PDA) for the global state account
+   ///
+   /// Derives the address of the global state account using the program ID and a
+   /// constant seed. The global state account contains program-wide configuration
+   /// such as fee settings and fee recipient.
+   ///
+   /// # Returns
+   ///
+   /// Returns the PDA public key derived from the GLOBAL_SEED
+   ///
+   /// # Examples
+   ///
+   /// ```
+   /// # use pumpfun::PumpFun;
+   /// # use solana_sdk::pubkey::Pubkey;
+   /// #
+   /// let global_pda: Pubkey = PumpFun::get_global_pda();
+   /// println!("Global state account: {}", global_pda);
+   /// ```
+   pub fn get_global_pda() -> Pubkey {
+      let seeds: &[&[u8]; 1] = &[constants::seeds::GLOBAL_SEED];
+      let program_id: &Pubkey = &constants::accounts::PUMPFUN;
+      Pubkey::find_program_address(seeds, program_id).0
+   }
 
-    /// Gets the Program Derived Address (PDA) for the mint authority
-    ///
-    /// Derives the address of the mint authority PDA using the program ID and a
-    /// constant seed. The mint authority PDA is the authority that can mint new
-    /// tokens for any token created through the Pump.fun program.
-    ///
-    /// # Returns
-    ///
-    /// Returns the PDA public key derived from the MINT_AUTHORITY_SEED
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use pumpfun::PumpFun;
-    /// # use solana_sdk::pubkey::Pubkey;
-    /// #
-    /// let mint_authority: Pubkey = PumpFun::get_mint_authority_pda();
-    /// println!("Mint authority account: {}", mint_authority);
-    /// ```
-    pub fn get_mint_authority_pda() -> Pubkey {
-        let seeds: &[&[u8]; 1] = &[constants::seeds::MINT_AUTHORITY_SEED];
-        let program_id: &Pubkey = &constants::accounts::PUMPFUN;
-        Pubkey::find_program_address(seeds, program_id).0
-    }
+   /// Gets the Program Derived Address (PDA) for the mint authority
+   ///
+   /// Derives the address of the mint authority PDA using the program ID and a
+   /// constant seed. The mint authority PDA is the authority that can mint new
+   /// tokens for any token created through the Pump.fun program.
+   ///
+   /// # Returns
+   ///
+   /// Returns the PDA public key derived from the MINT_AUTHORITY_SEED
+   ///
+   /// # Examples
+   ///
+   /// ```
+   /// # use pumpfun::PumpFun;
+   /// # use solana_sdk::pubkey::Pubkey;
+   /// #
+   /// let mint_authority: Pubkey = PumpFun::get_mint_authority_pda();
+   /// println!("Mint authority account: {}", mint_authority);
+   /// ```
+   pub fn get_mint_authority_pda() -> Pubkey {
+      let seeds: &[&[u8]; 1] = &[constants::seeds::MINT_AUTHORITY_SEED];
+      let program_id: &Pubkey = &constants::accounts::PUMPFUN;
+      Pubkey::find_program_address(seeds, program_id).0
+   }
 
-    /// Gets the Program Derived Address (PDA) for a token's bonding curve account
-    ///
-    /// Derives the address of a token's bonding curve account using the program ID,
-    /// a constant seed, and the token mint address. The bonding curve account stores
-    /// the state and parameters that govern the token's price dynamics.
-    ///
-    /// # Arguments
-    ///
-    /// * `mint` - Public key of the token mint
-    ///
-    /// # Returns
-    ///
-    /// Returns Some(PDA) if derivation succeeds, or None if it fails
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use pumpfun::PumpFun;
-    /// # use solana_sdk::{pubkey, pubkey::Pubkey};
-    /// #
-    /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
-    /// if let Some(bonding_curve) = PumpFun::get_bonding_curve_pda(&mint) {
-    ///     println!("Bonding curve account: {}", bonding_curve);
-    /// }
-    /// ```
-    pub fn get_bonding_curve_pda(mint: &Pubkey) -> Option<Pubkey> {
-        let seeds: &[&[u8]; 2] = &[constants::seeds::BONDING_CURVE_SEED, mint.as_ref()];
-        let program_id: &Pubkey = &constants::accounts::PUMPFUN;
-        let pda: Option<(Pubkey, u8)> = Pubkey::try_find_program_address(seeds, program_id);
-        pda.map(|pubkey| pubkey.0)
-    }
+   /// Gets the Program Derived Address (PDA) for a token's bonding curve account
+   ///
+   /// Derives the address of a token's bonding curve account using the program ID,
+   /// a constant seed, and the token mint address. The bonding curve account stores
+   /// the state and parameters that govern the token's price dynamics.
+   ///
+   /// # Arguments
+   ///
+   /// * `mint` - Public key of the token mint
+   ///
+   /// # Returns
+   ///
+   /// Returns Some(PDA) if derivation succeeds, or None if it fails
+   ///
+   /// # Examples
+   ///
+   /// ```
+   /// # use pumpfun::PumpFun;
+   /// # use solana_sdk::{pubkey, pubkey::Pubkey};
+   /// #
+   /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+   /// if let Some(bonding_curve) = PumpFun::get_bonding_curve_pda(&mint) {
+   ///     println!("Bonding curve account: {}", bonding_curve);
+   /// }
+   /// ```
+   pub fn get_bonding_curve_pda(mint: &Pubkey) -> Option<Pubkey> {
+      let seeds: &[&[u8]; 2] = &[constants::seeds::BONDING_CURVE_SEED, mint.as_ref()];
+      let program_id: &Pubkey = &constants::accounts::PUMPFUN;
+      let pda: Option<(Pubkey, u8)> = Pubkey::try_find_program_address(seeds, program_id);
+      pda.map(|pubkey| pubkey.0)
+   }
 
-    /// Gets the Program Derived Address (PDA) for a token's metadata account
-    ///
-    /// Derives the address of a token's metadata account following the Metaplex Token Metadata
-    /// standard. The metadata account stores information about the token such as name,
-    /// symbol, and URI pointing to additional metadata.
-    ///
-    /// # Arguments
-    ///
-    /// * `mint` - Public key of the token mint
-    ///
-    /// # Returns
-    ///
-    /// Returns the PDA public key for the token's metadata account
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use pumpfun::PumpFun;
-    /// # use solana_sdk::{pubkey, pubkey::Pubkey};
-    /// #
-    /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
-    /// let metadata_pda = PumpFun::get_metadata_pda(&mint);
-    /// println!("Token metadata account: {}", metadata_pda);
-    /// ```
-    pub fn get_metadata_pda(mint: &Pubkey) -> Pubkey {
-        let seeds: &[&[u8]; 3] = &[
-            constants::seeds::METADATA_SEED,
-            constants::accounts::MPL_TOKEN_METADATA.as_ref(),
-            mint.as_ref(),
-        ];
-        let program_id: &Pubkey = &constants::accounts::MPL_TOKEN_METADATA;
-        Pubkey::find_program_address(seeds, program_id).0
-    }
+   /// Gets the Program Derived Address (PDA) for a token's metadata account
+   ///
+   /// Derives the address of a token's metadata account following the Metaplex Token Metadata
+   /// standard. The metadata account stores information about the token such as name,
+   /// symbol, and URI pointing to additional metadata.
+   ///
+   /// # Arguments
+   ///
+   /// * `mint` - Public key of the token mint
+   ///
+   /// # Returns
+   ///
+   /// Returns the PDA public key for the token's metadata account
+   ///
+   /// # Examples
+   ///
+   /// ```
+   /// # use pumpfun::PumpFun;
+   /// # use solana_sdk::{pubkey, pubkey::Pubkey};
+   /// #
+   /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+   /// let metadata_pda = PumpFun::get_metadata_pda(&mint);
+   /// println!("Token metadata account: {}", metadata_pda);
+   /// ```
+   pub fn get_metadata_pda(mint: &Pubkey) -> Pubkey {
+      let seeds: &[&[u8]; 3] = &[
+         constants::seeds::METADATA_SEED,
+         constants::accounts::MPL_TOKEN_METADATA.as_ref(),
+         mint.as_ref(),
+      ];
+      let program_id: &Pubkey = &constants::accounts::MPL_TOKEN_METADATA;
+      Pubkey::find_program_address(seeds, program_id).0
+   }
 
-    /// Gets the global state account data containing program-wide configuration
-    ///
-    /// Fetches and deserializes the global state account which contains program-wide
-    /// configuration parameters such as:
-    /// - Fee basis points for trading
-    /// - Fee recipient account
-    /// - Bonding curve parameters
-    /// - Other platform-wide settings
-    ///
-    /// # Returns
-    ///
-    /// Returns the deserialized GlobalAccount if successful, or a ClientError if the operation fails
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - The account cannot be found on-chain
-    /// - The account data cannot be properly deserialized
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
-    /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
-    /// # use std::sync::Arc;
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let payer = Arc::new(Keypair::new());
-    /// # let commitment = CommitmentConfig::confirmed();
-    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-    /// # let client = PumpFun::new(payer, cluster);
-    /// let global = client.get_global_account().await?;
-    /// println!("Fee basis points: {}", global.fee_basis_points);
-    /// println!("Fee recipient: {}", global.fee_recipient);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn get_global_account(&self) -> Result<accounts::GlobalAccount, error::ClientError> {
-        let global: Pubkey = Self::get_global_pda();
+   /// Gets the global state account data containing program-wide configuration
+   ///
+   /// Fetches and deserializes the global state account which contains program-wide
+   /// configuration parameters such as:
+   /// - Fee basis points for trading
+   /// - Fee recipient account
+   /// - Bonding curve parameters
+   /// - Other platform-wide settings
+   ///
+   /// # Returns
+   ///
+   /// Returns the deserialized GlobalAccount if successful, or a ClientError if the operation fails
+   ///
+   /// # Errors
+   ///
+   /// Returns an error if:
+   /// - The account cannot be found on-chain
+   /// - The account data cannot be properly deserialized
+   ///
+   /// # Examples
+   ///
+   /// ```no_run
+   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
+   /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
+   /// # use std::sync::Arc;
+   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+   /// # let payer = Arc::new(Keypair::new());
+   /// # let commitment = CommitmentConfig::confirmed();
+   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+   /// # let client = PumpFun::new(payer, cluster);
+   /// let global = client.get_global_account().await?;
+   /// println!("Fee basis points: {}", global.fee_basis_points);
+   /// println!("Fee recipient: {}", global.fee_recipient);
+   /// # Ok(())
+   /// # }
+   /// ```
+   pub async fn get_global_account(&self) -> Result<accounts::GlobalAccount, error::ClientError> {
+      let global: Pubkey = Self::get_global_pda();
 
-        let account = self
-            .rpc
-            .get_account(&global)
-            .await
-            .map_err(error::ClientError::SolanaClientError)?;
+      let account = self
+         .rpc
+         .get_account(&global)
+         .await
+         .map_err(error::ClientError::SolanaClientError)?;
 
-        solana_sdk::borsh1::try_from_slice_unchecked::<accounts::GlobalAccount>(&account.data)
-            .map_err(error::ClientError::BorshError)
-    }
+      solana_sdk::borsh1::try_from_slice_unchecked::<accounts::GlobalAccount>(&account.data)
+         .map_err(error::ClientError::BorshError)
+   }
 
-    /// Gets a token's bonding curve account data containing pricing parameters
-    ///
-    /// Fetches and deserializes a token's bonding curve account which contains the
-    /// state and parameters that determine the token's price dynamics, including:
-    /// - Current supply
-    /// - Reserve balance
-    /// - Bonding curve parameters
-    /// - Other token-specific configuration
-    ///
-    /// # Arguments
-    ///
-    /// * `mint` - Public key of the token mint
-    ///
-    /// # Returns
-    ///
-    /// Returns the deserialized BondingCurveAccount if successful, or a ClientError if the operation fails
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - The bonding curve PDA cannot be derived
-    /// - The account cannot be found on-chain
-    /// - The account data cannot be properly deserialized
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
-    /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair, pubkey};
-    /// # use std::sync::Arc;
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let payer = Arc::new(Keypair::new());
-    /// # let commitment = CommitmentConfig::confirmed();
-    /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
-    /// # let client = PumpFun::new(payer, cluster);
-    /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
-    /// let bonding_curve = client.get_bonding_curve_account(&mint).await?;
-    /// println!("Bonding Curve Account: {:#?}", bonding_curve);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn get_bonding_curve_account(
-        &self,
-        mint: &Pubkey,
-    ) -> Result<accounts::BondingCurveAccount, error::ClientError> {
-        let bonding_curve_pda =
-            Self::get_bonding_curve_pda(mint).ok_or(error::ClientError::BondingCurveNotFound)?;
+   /// Gets a token's bonding curve account data containing pricing parameters
+   ///
+   /// Fetches and deserializes a token's bonding curve account which contains the
+   /// state and parameters that determine the token's price dynamics, including:
+   /// - Current supply
+   /// - Reserve balance
+   /// - Bonding curve parameters
+   /// - Other token-specific configuration
+   ///
+   /// # Arguments
+   ///
+   /// * `mint` - Public key of the token mint
+   ///
+   /// # Returns
+   ///
+   /// Returns the deserialized BondingCurveAccount if successful, or a ClientError if the operation fails
+   ///
+   /// # Errors
+   ///
+   /// Returns an error if:
+   /// - The bonding curve PDA cannot be derived
+   /// - The account cannot be found on-chain
+   /// - The account data cannot be properly deserialized
+   ///
+   /// # Examples
+   ///
+   /// ```no_run
+   /// # use pumpfun::{PumpFun, common::types::{Cluster, PriorityFee}};
+   /// # use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair, pubkey};
+   /// # use std::sync::Arc;
+   /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+   /// # let payer = Arc::new(Keypair::new());
+   /// # let commitment = CommitmentConfig::confirmed();
+   /// # let cluster = Cluster::devnet(commitment, PriorityFee::default());
+   /// # let client = PumpFun::new(payer, cluster);
+   /// let mint = pubkey!("TokenM1ntPubk3yXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+   /// let bonding_curve = client.get_bonding_curve_account(&mint).await?;
+   /// println!("Bonding Curve Account: {:#?}", bonding_curve);
+   /// # Ok(())
+   /// # }
+   /// ```
+   pub async fn get_bonding_curve_account(
+      &self,
+      mint: &Pubkey,
+   ) -> Result<accounts::BondingCurveAccount, error::ClientError> {
+      let bonding_curve_pda =
+         Self::get_bonding_curve_pda(mint).ok_or(error::ClientError::BondingCurveNotFound)?;
 
-        let account = self
-            .rpc
-            .get_account(&bonding_curve_pda)
-            .await
-            .map_err(error::ClientError::SolanaClientError)?;
+      let account = self
+         .rpc
+         .get_account(&bonding_curve_pda)
+         .await
+         .map_err(error::ClientError::SolanaClientError)?;
 
-        solana_sdk::borsh1::try_from_slice_unchecked::<accounts::BondingCurveAccount>(&account.data)
-            .map_err(error::ClientError::BorshError)
-    }
+      solana_sdk::borsh1::try_from_slice_unchecked::<accounts::BondingCurveAccount>(&account.data)
+         .map_err(error::ClientError::BorshError)
+   }
+
+   /// Gets the creator vault address (for claiming pump creator fees)
+   ///
+   /// Derives the token creator's vault using the program ID,
+   /// a constant seed, and the creator's address.
+   ///
+   /// # Arguments
+   ///
+   /// * `creator` - Public key of the token's creator
+   ///
+   /// # Returns
+   ///
+   /// Returns Some(PDA) if derivation succeeds, or None if it fails
+   ///
+   /// # Examples
+   ///
+   /// ```
+   /// # use pumpfun::PumpFun;
+   /// # use solana_sdk::{pubkey, pubkey::Pubkey};
+   /// #
+   /// let creator = pubkey!("Amya8kr2bzEY9kyXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+   /// if let Some(bonding_curve) = PumpFun::get_creator_vault_pda(&creator) {
+   ///     println!("Creator vault address: {}", creator vault);
+   /// }
+   /// ```
+   pub fn get_creator_vault_pda(creator: &Pubkey) -> Option<Pubkey> {
+      let seeds: &[&[u8]; 2] = &[constants::seeds::CREATOR_VAULT_SEED, creator.as_ref()];
+      let program_id: &Pubkey = &constants::accounts::PUMPFUN;
+      let pda: Option<(Pubkey, u8)> = Pubkey::try_find_program_address(seeds, program_id);
+      pda.map(|pubkey| pubkey.0)
+   }
 }

--- a/src/utils/transaction.rs
+++ b/src/utils/transaction.rs
@@ -24,10 +24,10 @@ use crate::error;
 /// * `payer` - The primary account that will pay for the transaction fees
 /// * `instructions` - Slice of Solana instructions to include in the transaction
 /// * `additional_signers` - Optional slice of additional keypair signers that should sign the transaction,
-///                         in addition to the payer
+///   in addition to the payer
 /// * `address_lookup_table_accounts` - Optional slice of Address Lookup Table accounts to include,
-///                                    enabling versioned transactions with address table lookups
-///                                    (only available with "versioned-tx" feature)
+///   enabling versioned transactions with address table lookups
+///   (only available with "versioned-tx" feature)
 ///
 /// # Returns
 ///


### PR DESCRIPTION
This PR updates the SDK for account for pumpfun creator fee changes.

Modified in the following:
Both buy and sell instructions now accept an extra argument `creator: Pubkey`.
1) the current Buy::rent account (instruction account index 10) will become Buy::creator_vault account.

2) the currently unused Sell::associated_token_program account (instruction account index 8) will become Sell::creator_vault account.

3) updated TradeEvent by adding 6 new fields to the struct:
    pub fee_recipient: Pubkey,
    pub fee_basis_points: u64,
    pub fee: u64,
    pub creator: Pubkey,
    pub creator_fee_basis_points: u64,
    pub creator_fee: u64,